### PR TITLE
Fix template file resolving for packaged jarfiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.posterous</groupId>
   <artifactId>finatra</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.1-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <description>Sinatra clone on top of finagle-http</description>
   <inceptionYear>2012</inceptionYear>

--- a/src/main/scala/com/posterous/finatra/TemplateHandler.scala
+++ b/src/main/scala/com/posterous/finatra/TemplateHandler.scala
@@ -1,6 +1,7 @@
 package com.posterous.finatra
 
 import com.github.mustachejava._
+import com.twitter.io.TempFile
 import com.twitter.mustache._
 
 import java.io.IOException
@@ -29,8 +30,8 @@ class FinatraMustacheFactory extends DefaultMustacheFactory {
 class TemplateHandler {
 
   def captureTemplate(template: String, layout: String, exports: Any): String  = {
-    val tpath = new File("templates/" + template)
-    val lpath = new File("templates/layouts/" + layout)
+    val tpath = TempFile.fromResourcePath("/templates/" + template)
+    val lpath = TempFile.fromResourcePath("/templates/layouts/" + layout)
 
     //what remembers the templates
     val mf = new FinatraMustacheFactory


### PR DESCRIPTION
Using `new File(...)` doesn't work to resolve the template files inside packaged jars.
Since finatra already has a twitter/util dependency through finagle, used `TempFile` to solve this problem.

Also bumped the pom.xml to a snapshot version so local development doesn't clobber artifacts
