### PR TITLE
Pass controllers into AppService

### DIFF
--- a/src/main/scala/com/twitter/finatra/AppService.scala
+++ b/src/main/scala/com/twitter/finatra/AppService.scala
@@ -16,6 +16,7 @@
 package com.twitter.finatra
 
 import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finatra_core.ControllerCollection
 import com.twitter.util.Future
 import org.jboss.netty.buffer.ChannelBuffers.copiedBuffer
 import org.jboss.netty.handler.codec.http._
@@ -24,7 +25,8 @@ import org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
 import org.jboss.netty.util.CharsetUtil.UTF_8
 
 
-class AppService extends Service[HttpRequest, HttpResponse]{
+class AppService(controllers: ControllerCollection[Request, Future[Response], Future[HttpResponse]])
+  extends Service[HttpRequest, HttpResponse]{
 
   def notFoundResponse = {
     val resp = new DefaultHttpResponse(HTTP_1_1, NOT_FOUND)
@@ -35,7 +37,7 @@ class AppService extends Service[HttpRequest, HttpResponse]{
   def apply(rawRequest: HttpRequest) = {
     val request = RequestAdapter(rawRequest)
 
-    FinatraServer.controllers.dispatch(request) match {
+    controllers.dispatch(request) match {
       case Some(response) =>
         response.asInstanceOf[Future[HttpResponse]]
       case None =>

--- a/src/main/scala/com/twitter/finatra/FinatraServer.scala
+++ b/src/main/scala/com/twitter/finatra/FinatraServer.scala
@@ -51,7 +51,7 @@ object FinatraServer extends Logging {
     this.docroot = docroot
     this.pidPath = pidPath
 
-    val appService = new AppService
+    val appService = new AppService(controllers)
     val fileService = new FileService
 
     val envPort = Option(System.getenv("PORT"))


### PR DESCRIPTION
`AppService` uses the `FinatraServer` singleton's controllers field by default. It's a bit better if you can pass in the controllers (in case people want to roll their own server rather than using FinatraServer)
