### PR TITLE
Fix Set-Cookier header bug in response

### DIFF
--- a/src/main/scala/com/twitter/finatra/Response.scala
+++ b/src/main/scala/com/twitter/finatra/Response.scala
@@ -154,7 +154,7 @@ class Response extends Logging {
       resp.setHeader(xs._1, xs._2)
     }
 
-    if (this.hasCookies) resp.setHeader("Cookie", cookies.encode)
+    if (this.hasCookies) resp.setHeader("Set-Cookie", cookies.encode)
 
     setContent(resp)
     FinagleResponse(resp)

--- a/src/test/scala/com/twitter/finatra/CookieSpec.scala
+++ b/src/test/scala/com/twitter/finatra/CookieSpec.scala
@@ -39,12 +39,12 @@ class CookieSpec extends SpecHelper {
 
   "basic k/v cookie" should "have Foo:Bar" in {
     get("/sendCookie")
-    response.getHeader("Cookie") should be ("Foo=Bar")
+    response.getHeader("Set-Cookie") should be ("Foo=Bar")
   }
 
   "advanced Cookie" should "have Biz:Baz&Secure=true" in {
     get("/sendAdvCookie")
-    response.getHeader("Cookie") should be ("Biz=Baz; Secure")
+    response.getHeader("Set-Cookie") should be ("Biz=Baz; Secure")
   }
 
 }


### PR DESCRIPTION
While I'm writing some toy program, I found the bug.

I believe response header has to return "Set-Cookie" not "Cookie".
Otherwise, we cannot store any Cookie information in browser.
