### PR TITLE
Force mustache partials to be uncached from the local filesystem in development mode.

### DIFF
--- a/src/main/scala/com/twitter/finatra/View.scala
+++ b/src/main/scala/com/twitter/finatra/View.scala
@@ -16,24 +16,57 @@
 package com.twitter.finatra
 
 import com.github.mustachejava._
-import com.twitter.mustache._
-
-import java.io._
+import com.google.common.base.Charsets;
 import com.twitter.io.TempFile
+import com.twitter.mustache._
+import java.io._
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 
-class FinatraMustacheFactory extends DefaultMustacheFactory {
+class FinatraMustacheFactory(baseTemplatePath:String) extends DefaultMustacheFactory {
   override def encode(str: String, wtr: Writer) {
     wtr.append(str, 0, str.length)
   }
+
+  override def getReader(resourceName:String) : Reader = {
+    if (!"development".equals(Config.get("env"))) {
+      super.getReader(resourceName)
+    }
+    // In development mode, we look to the local file
+    // system and avoid using the classloader which has
+    // priority in DefaultMustacheFactory.getReader
+    else {
+      val file:File = new File(baseTemplatePath, resourceName)
+      if (file.exists() && file.isFile()) {
+        try {
+          new BufferedReader(new InputStreamReader(new FileInputStream(file),
+            Charsets.UTF_8));
+        } catch {
+          case exception:FileNotFoundException =>
+            throw new MustacheException("Found file, could not open: " + file, exception)
+        }
+      }
+      else {
+        throw new MustacheException("Template '" + resourceName + "' not found at " + file);
+      }
+
+    }
+  }
+
+  /**
+   * Invalidate template caches during development
+   */
+  def invalidateMustacheCaches() : Unit = {
+    mustacheCache.invalidateAll()
+    templateCache.invalidateAll()
+  }
+
 }
 
 object View {
-  lazy val mustacheFactory  = new FinatraMustacheFactory
+  lazy val mustacheFactory  = new FinatraMustacheFactory(Config.get("local_docroot"))
   var baseTemplatePath      = Config.get("template_path")
   def templatePath          = baseTemplatePath
-
 
   mustacheFactory.setObjectHandler(new TwitterObjectHandler)
   mustacheFactory.setExecutorService(Executors.newCachedThreadPool)
@@ -50,6 +83,13 @@ abstract class View extends Callable[String] {
   def mustache                    = factory.compile(new InputStreamReader(FileResolver.getInputStream(templatePath)), "template")
 
   def render = {
+    // In development mode, we flush all of our template
+    // caches on each render. Otherwise, partials will
+    // remain unchanged in the browser while being edited.
+    if ("development".equals(Config.get("env"))) {
+      factory.invalidateMustacheCaches()
+    }
+
     val output = new StringWriter
     mustache.execute(output, this).flush()
     output.toString


### PR DESCRIPTION
Mustache.java's DefaultMustacheFactory uses the [classloader](https://github.com/spullara/mustache.java/blob/master/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java#L97) to load mustache partials even when Finatra is in development mode. This has the effect of causing any partials to be loaded once from target/classes with any changes not showing up until the Finatra service is bounced.

This patch inhibits the use of the [classloader](https://github.com/spullara/mustache.java/blob/master/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java#L97) when loading resources while in development mode. It also flushes mustache.java's [template cache](https://github.com/spullara/mustache.java/blob/master/compiler/src/main/java/com/github/mustachejava/DefaultMustacheFactory.java#L34) on each render.
