### PR TITLE
Handle downstream exceptions and display the error handler.

### DIFF
--- a/src/main/scala/com/twitter/finatra/Request.scala
+++ b/src/main/scala/com/twitter/finatra/Request.scala
@@ -27,7 +27,7 @@ class Request(rawRequest: FinagleRequest) extends RequestProxy {
   var routeParams: Map[String, String] = Map.empty
 
   var request = rawRequest
-  var error: Option[Exception] = None
+  var error: Option[Throwable] = None
 
   def accepts: Seq[ContentType] = {
     val accept = this.getHeader("Accept")


### PR DESCRIPTION
Howdy, I'm a new guy at twitter working on zipkin.

Here's a patch I cooked up for a problem we're seeing when downstream finagle requests bubble up exceptions.  Currently when a route returns Future.exception, finatra returns empty content on the socket.  This patch handles these exceptions and routes to the error handlers where we can correctly return 500 status.
