### PR TITLE
Support OPTIONS HTTP method

### DIFF
--- a/src/main/scala/com/twitter/finatra/Controller.scala
+++ b/src/main/scala/com/twitter/finatra/Controller.scala
@@ -32,6 +32,7 @@ class Controller(statsReceiver: StatsReceiver = NullStatsReceiver) extends Loggi
   def put(path: String)   (callback: Request => Future[Response]) { addRoute(HttpMethod.PUT,    path)(callback) }
   def head(path: String)  (callback: Request => Future[Response]) { addRoute(HttpMethod.HEAD,   path)(callback) }
   def patch(path: String) (callback: Request => Future[Response]) { addRoute(HttpMethod.PATCH,  path)(callback) }
+  def options(path: String)(callback: Request => Future[Response]){ addRoute(HttpMethod.OPTIONS, path)(callback) }
 
   def notFound(callback: Request => Future[Response]) {
     notFoundHandler = Option(callback)

--- a/src/main/scala/com/twitter/finatra/test/SpecHelper.scala
+++ b/src/main/scala/com/twitter/finatra/test/SpecHelper.scala
@@ -81,4 +81,8 @@ abstract class SpecHelper extends FlatSpec with ShouldMatchers {
     buildRequest(HttpMethod.PATCH,path,params,headers)
   }
 
+  def options(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map()) {
+    buildRequest(HttpMethod.OPTIONS,path,params,headers)
+  }
+
 }

--- a/src/test/scala/com/twitter/finatra/ExampleSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ExampleSpec.scala
@@ -105,6 +105,10 @@ class ExampleSpec extends SpecHelper {
       render.plain("ok").toFuture
     }
 
+    options("/some/resource") { request =>
+      render.plain("usage description").toFuture
+    }
+
     /**
      * Rendering views
      *
@@ -291,6 +295,11 @@ class ExampleSpec extends SpecHelper {
     get("/redirect")
     response.body should equal("Redirecting to <a href=\"http://localhost:7070/\">http://localhost:7070/</a>.")
     response.code should equal(301)
+  }
+
+  "OPTIONS /some/resource" should "respond with usage description" in {
+    options("/some/resource")
+    response.body should equal("usage description")
   }
 
   "GET /template" should "respond with a rendered template" in {


### PR DESCRIPTION
Allow explicit support for the OPTIONS method.

Ideally, could be smart enough to generate the appropriate `Allow` headers based on defined actions.
