### PR TITLE
Let people choose their test framework

### DIFF
--- a/src/main/scala/com/twitter/finatra/test/SpecHelper.scala
+++ b/src/main/scala/com/twitter/finatra/test/SpecHelper.scala
@@ -21,8 +21,6 @@ import org.jboss.netty.util.CharsetUtil.UTF_8
 import com.twitter.finagle.http.{Request => FinagleRequest, Response => FinagleResponse}
 import com.twitter.finatra.{AppService, ControllerCollection, Controller}
 import org.jboss.netty.handler.codec.http.HttpMethod
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
 
 class MockResponse(val originalResponse: FinagleResponse) {
 
@@ -34,7 +32,7 @@ class MockResponse(val originalResponse: FinagleResponse) {
 
 }
 
-abstract class SpecHelper extends FlatSpec with ShouldMatchers {
+trait SpecHelper {
 
   def response  = new MockResponse(lastResponse.get)
   var lastResponse:Future[FinagleResponse] = null
@@ -86,3 +84,4 @@ abstract class SpecHelper extends FlatSpec with ShouldMatchers {
   }
 
 }
+

--- a/src/test/scala/com/twitter/finatra/CookieSpec.scala
+++ b/src/test/scala/com/twitter/finatra/CookieSpec.scala
@@ -33,7 +33,7 @@ class CookieApp extends Controller {
 
 }
 
-class CookieSpec extends SpecHelper {
+class CookieSpec extends FlatSpecHelper {
 
   def app = { new CookieApp }
 

--- a/src/test/scala/com/twitter/finatra/ExampleSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ExampleSpec.scala
@@ -15,7 +15,7 @@
  */
 package com.twitter.finatra
 
-import test.SpecHelper
+import com.twitter.finatra.test.{FlatSpecHelper}
 import com.twitter.finatra.ContentType._
 import com.twitter.ostrich.stats.Stats
 
@@ -24,7 +24,7 @@ import com.twitter.ostrich.stats.Stats
  README.markdown, all new generated apps, and the finatra_example repo
  */
 
-class ExampleSpec extends SpecHelper {
+class ExampleSpec extends FlatSpecHelper {
 
   /* ###BEGIN_APP### */
 

--- a/src/test/scala/com/twitter/finatra/ServerSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ServerSpec.scala
@@ -27,7 +27,7 @@ class TestApp extends Controller {
 
 }
 
-class ServerSpec extends SpecHelper {
+class ServerSpec extends FlatSpecHelper {
 
   def app = { new TestApp }
 

--- a/src/test/scala/com/twitter/finatra/test/FlatSpecHelper.scala
+++ b/src/test/scala/com/twitter/finatra/test/FlatSpecHelper.scala
@@ -1,0 +1,6 @@
+package com.twitter.finatra.test
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+
+abstract class FlatSpecHelper extends FlatSpec with ShouldMatchers with SpecHelper


### PR DESCRIPTION
Our services use scalatest's `FunSpec` or specs2, which requires us to copy-and-paste the `SpecHelper.scala` code just to remove the dependency on `FlatSpec`.

This PR avoids the problem by decoupling `SpecHelper` from `FlatSpec`. 

Given this is a breaking change on the API, I am not sure what approach to take. I've created a `FlatSpecHelper` which should behave exactly like the old `SpecHelper`, and made it part of the test source as I believe it would be nice if Finatra itself doesnt bring a transitive dependency on scalatest. I guess keeping `SpecHelper` and extracting the common bits in a trait with a different name would also work, happy to do that if it's better.
