### PR TITLE
New stop() method stops the service but doesn't kill the process

### DIFF
--- a/src/main/scala/com/twitter/finatra/FinatraServer.scala
+++ b/src/main/scala/com/twitter/finatra/FinatraServer.scala
@@ -25,6 +25,7 @@ import com.twitter.finagle.tracing.{Tracer, NullTracer}
 import com.twitter.conversions.storage._
 import com.twitter.ostrich.admin._
 import com.twitter.ostrich.admin.{Service => OstrichService}
+import com.twitter.util.Duration
 
 object FinatraServer {
 
@@ -79,8 +80,15 @@ class FinatraServer extends Logging with OstrichService {
   def shutdown() {
     logger.info("shutting down")
     logger.info("finatra process shutting down")
-    server foreach { s => s.close()() }
+    stop
     System.exit(0)
+  }
+
+
+  def stop() {
+    server foreach {
+      s => s.close(Duration.Zero)()
+    }
   }
 
   def start() {

--- a/src/test/scala/com/twitter/finatra/FinatraServerSpec.scala
+++ b/src/test/scala/com/twitter/finatra/FinatraServerSpec.scala
@@ -15,30 +15,30 @@
  */
 package com.twitter.finatra.test
 
-import com.twitter.finatra.{ConfigFlags, Config, Controller, FinatraServer}
-import com.twitter.logging.Logger
+import com.twitter.finatra.{Controller, FinatraServer}
 
 
 class TestApp extends Controller {
 
   get("/hey") {
-    request =>  render.plain("hello").toFuture
+    request => render.plain("hello").toFuture
   }
 
 }
 
 class FinatraServerSpec extends SpecHelper {
 
-  def app = { new TestApp }
+  val app = new TestApp
 
   "app" should "register" in {
     val server = new FinatraServer
     server.register(app)
     server.start()
 
-    server.logger.debug("SHOULD NOT APPEAR!!")
-    server.logger.info("SHOULD SEE THIS")
-    server.shutdown()
+    get("/hey")
+    response.body should equal("hello")
+
+    server.stop()
   }
 
 }


### PR DESCRIPTION
This makes it easier to embed Finatra and run Integration Tests.
The shutdown() method is kept, so this won't break any users, but
we should consider deprecating it.

Our own tests were also being killed before completion --besides
not testing anything...--, fixed.
