### PR TITLE
Compare request.path to string literal instead of char literal

### DIFF
--- a/src/main/scala/com/twitter/finatra/FileService.scala
+++ b/src/main/scala/com/twitter/finatra/FileService.scala
@@ -101,7 +101,7 @@ class FileService extends SimpleFilter[FinagleRequest, FinagleResponse] with Log
   }
 
   def apply(request: FinagleRequest, service: Service[FinagleRequest, FinagleResponse]): Future[FinagleResponse] = {
-    if (FileResolver.hasFile(request.path) && request.path != '/') {
+    if (FileResolver.hasFile(request.path) && request.path != "/") {
       val fh  = FileResolver.getInputStream(request.path)
       val b   = IOUtils.toByteArray(fh)
 


### PR DESCRIPTION
Hey there!

I've been trying to get zipkin setup, which depends on finatra for the zipkin-web component. I've been experiencing the issue that I described on the zipkin-user mailing list here: https://groups.google.com/forum/#!topic/zipkin-user/6T0XQbk1qu0

It looks like the code was doing String and Char comparison (since `"/" != '/'`), which in the case of my setup was taking the 'serve file' branch in the `FileService` and serving my root partition directory contents.

I tried writing a good unit test for this, but since this class depends a lot on outside `System` state, I've deferred that for now. I'd be willing to submit a patch that reworks `FileResolver` to not explicitly rely on the global `System` state so that this would be easier to test if that's a patch you're willing to accept.

Let me know what you think!

Blake
