### PR TITLE
FinatraServer should take the generic Filters, not SimpleFilters

### DIFF
--- a/src/main/scala/com/twitter/finatra/FinatraServer.scala
+++ b/src/main/scala/com/twitter/finatra/FinatraServer.scala
@@ -31,7 +31,7 @@ import java.io.{FileOutputStream, File, FileNotFoundException}
 class FinatraServer extends FinatraTwitterServer {
 
   val controllers:  ControllerCollection = new ControllerCollection
-  var filters:      Seq[SimpleFilter[FinagleRequest, FinagleResponse]] = Seq.empty
+  var filters:      Seq[Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]] = Seq.empty
   val pid:          String = ManagementFactory.getRuntimeMXBean.getName.split('@').head
 
   var secureServer: Option[ListeningServer] = None
@@ -45,7 +45,7 @@ class FinatraServer extends FinatraTwitterServer {
 
   def register(app: Controller) { controllers.add(app) }
 
-  def addFilter(filter: SimpleFilter[FinagleRequest, FinagleResponse]) {
+  def addFilter(filter: Filter[FinagleRequest, FinagleResponse,FinagleRequest, FinagleResponse]) {
     filters = filters ++ Seq(filter)
   }
 


### PR DESCRIPTION
I am not too sure if there was ever a reason to use the limited subtype instead of Filter, but this was requiring us to wrap the [CorsFilter](https://github.com/twitter/finagle/blob/8c30bd2ddddff64e5d51634e8ef678c47dd67177/finagle-http/src/main/scala/com/twitter/finagle/http/filter/Cors.scala) into a dummy SimpleFilter.
