### PR TITLE
Fixed build by reverting to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.10.2</scala.version>
+    <scala.version>2.10.0</scala.version>
   </properties>
   <profiles>
     <profile>


### PR DESCRIPTION
This is a funny one. I don't know if reverting is the best option, but the fact that **the build was apparently broken for a very long time scares me**. What do people run as a pre-checkin build?

Running `mvn test` was failing with:

```
*** RUN ABORTED ***
  java.lang.IncompatibleClassChangeError: class com.twitter.finatra.Examp
leSpec has interface com.twitter.finatra.test.SpecHelper as super class
  at java.lang.ClassLoader.defineClass1(Native Method)
  at java.lang.ClassLoader.defineClassCond(ClassLoader.java:637)
  at java.lang.ClassLoader.defineClass(ClassLoader.java:621)
```

Turns out the answer was in this warning just before the error:

```
[INFO] --- scala-maven-plugin:3.1.0:compile (default) @ finatra ---
[WARNING]  Expected all dependencies to require Scala version: 2.10.2
[WARNING]  com.twitter:finatra:1.4.2-SNAPSHOT requires scala version: 2.10.2
[WARNING]  com.twitter:twitter-server_2.10:1.1.0 requires scala version: 2.10.0
[WARNING] Multiple versions of scala libraries detected!
```

So this reverted to Scala 2.10.0 until twitter-server and others upgrade.
