### PR TITLE
Updated `finatra new` to work with 1.4.1

### DIFF
--- a/script/finatra/share/App.scala
+++ b/script/finatra/share/App.scala
@@ -7,5 +7,5 @@ object App extends FinatraServer {
 
   __EXAMPLEAPP__
 
-  register(app)
+  register(new ExampleApp())
 }

--- a/script/finatra/share/AppSpec.scala
+++ b/script/finatra/share/AppSpec.scala
@@ -3,11 +3,14 @@ package ###PACKAGE_NAME###
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 import com.twitter.finatra.test._
+import com.twitter.finatra.FinatraServer
 import ###PACKAGE_NAME###._
 
 class AppSpec extends FlatSpecHelper {
 
   val app = new App.ExampleApp
+  override val server = new FinatraServer
+  server.register(app)
 
   __EXAMPLESPEC__
 

--- a/src/main/scala/com/twitter/finatra/FinatraServer.scala
+++ b/src/main/scala/com/twitter/finatra/FinatraServer.scala
@@ -36,7 +36,7 @@ class FinatraServer extends FinatraTwitterServer {
 
   var secureServer: Option[ListeningServer] = None
   var server:       Option[ListeningServer] = None
-  var adminServer:       Option[ListeningServer] = None
+  var adminServer:  Option[ListeningServer] = None
 
   def allFilters(baseService: Service[FinagleRequest, FinagleResponse]):
     Service[FinagleRequest, FinagleResponse] = {

--- a/src/test/scala/com/twitter/finatra/ExampleSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ExampleSpec.scala
@@ -240,9 +240,6 @@ class ExampleSpec extends FlatSpecHelper {
 
   }
 
-  val server = new FinatraServer
-  server.register(new ExampleApp)
-
   /* ###END_APP### */
 
 


### PR DESCRIPTION
I was having some trouble with building a new app from scratch with `finatra new` with 1.4.1. This isn't backwards compatible with 1.4.0. There is probably a better fix from someone more familiar with the project, but I thought it was easier to show what I'm talking about with a pull request.
