### PR TITLE
set Content-Length on static file responses

### DIFF
--- a/src/main/scala/com/twitter/finatra/FileService.scala
+++ b/src/main/scala/com/twitter/finatra/FileService.scala
@@ -107,13 +107,12 @@ class FileService extends SimpleFilter[FinagleRequest, FinagleResponse] with App
       val fh  = FileResolver.getInputStream(path)
       val b   = IOUtils.toByteArray(fh)
 
-      fh.read(b)
-
       val response  = request.response
       val mtype     = FileService.extMap.getContentType('.' + request.path.toString.split('.').last)
 
       response.status = OK
       response.headers.set("Content-Type", mtype)
+      response.headers.set("Content-Length", b.length)
       response.setContent(copiedBuffer(b))
 
       Future.value(response)

--- a/src/test/scala/com/twitter/finatra/FileServiceSpec.scala
+++ b/src/test/scala/com/twitter/finatra/FileServiceSpec.scala
@@ -9,7 +9,7 @@ import com.twitter.finagle.http.service.NullService
 class FileServiceSpec extends ShouldSpec {
   val fileService = new FileService
 
-  //We assert the content, rather than just 200, since FileService always defers to AppService to render the 404.
+  // We assert the content, rather than just 200, since FileService always defers to AppService to render the 404.
   "looking up static files" should "return gif content" in {
     val r = FinagleRequest("/dealwithit.gif")
     val response = fileService(r, NullService)
@@ -20,5 +20,11 @@ class FileServiceSpec extends ShouldSpec {
     val r = FinagleRequest("/dealwithit.gif", "foo" -> "bar")
     val response = fileService(r, NullService)
     Await.result(response).getContent().array().length should not equal 0
+  }
+
+  "looking up static files" should "set Content-Length" in {
+    val r = FinagleRequest("/dealwithit.gif", "foo" -> "bar")
+    val response = fileService(r, NullService)
+    Await.result(response).contentLength should equal (Some(422488L))
   }
 }


### PR DESCRIPTION
I also removed the extraneous call to InputStream.read -- IOUtils.toByteArray will already have consumed the entire InputStream. Also, if there was anything left, the read call would pave over the start of the byte array.
