### PR TITLE
Add helper for setting contentType

### DIFF
--- a/src/main/scala/com/twitter/finatra/ResponseBuilder.scala
+++ b/src/main/scala/com/twitter/finatra/ResponseBuilder.scala
@@ -167,6 +167,11 @@ class ResponseBuilder {
     this
   }
 
+  def contentType(ct: String): ResponseBuilder = {
+    this.header("Content-Type", ct)
+    this
+  }
+
   def static(path: String): ResponseBuilder = {
     val fullAssetPath = new File(config.assetPath(), path).toString
     if (FileResolver.hasFile(fullAssetPath) && path != '/') {


### PR DESCRIPTION
The docs indicate that this is how you should set contentType:

`render.body("custom response").contentType("application/mine").toFuture`

I think the helper in this pull request is necessary to make that syntax possible, because without it I get the following error:

`Option[String] does not take parameters`
