### PR TITLE
Updated SpecHelper to support a body for POST, PUT and OPTIONS methods

### DIFF
--- a/src/main/scala/com/twitter/finatra/test/SpecHelper.scala
+++ b/src/main/scala/com/twitter/finatra/test/SpecHelper.scala
@@ -43,12 +43,12 @@ trait SpecHelper {
     executeRequest(HttpMethod.GET,path,params,headers)
   }
 
-  def post(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map()) {
-    executeRequest(HttpMethod.POST,path,params,headers)
+  def post(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map(), body:AnyRef=null) {
+    executeRequest(HttpMethod.POST,path,params,headers,body)
   }
 
-  def put(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map()) {
-    executeRequest(HttpMethod.PUT,path,params,headers)
+  def put(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map(), body:AnyRef=null) {
+    executeRequest(HttpMethod.PUT,path,params,headers,body)
   }
 
   def delete(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map()) {
@@ -63,8 +63,8 @@ trait SpecHelper {
     executeRequest(HttpMethod.PATCH,path,params,headers)
   }
 
-  def options(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map()) {
-    executeRequest(HttpMethod.OPTIONS,path,params,headers)
+  def options(path:String, params:Map[String,String]=Map(), headers:Map[String,String]=Map(), body:AnyRef=null) {
+    executeRequest(HttpMethod.OPTIONS,path,params,headers,body)
   }
 
   def send(request: FinagleRequest) {
@@ -75,10 +75,11 @@ trait SpecHelper {
     method: HttpMethod,
     path: String,
     params: Map[String, String] = Map(),
-    headers: Map[String,String] = Map()
+    headers: Map[String,String] = Map(),
+    body: AnyRef = null
     ) {
     val app = MockApp(server)
-    val result: MockResult = app.execute(method = method, path = path, params = params, headers = headers)
+    val result: MockResult = app.execute(method = method, path = path, params = params, headers = headers, body = body)
     lastResponse = result.response
   }
 

--- a/src/test/scala/com/twitter/finatra/test/SampleSpec.scala
+++ b/src/test/scala/com/twitter/finatra/test/SampleSpec.scala
@@ -37,4 +37,61 @@ class SampleSpec extends FlatSpec with ShouldMatchers {
     response.code should be(200)
     response.body should be("hello world")
   }
+
+  class EchoController extends Controller {
+    post("/testing") {
+      request => render.body(request.getContentString()).status(200).toFuture
+    }
+
+    put("/testing") {
+      request => render.body(request.getContentString()).status(200).toFuture
+    }
+
+    options("/testing") {
+      request => render.body(request.getContentString()).status(200).toFuture
+    }
+  }
+
+  "SpecHelper" should "allow us to submit an HTTP body for POST method" in {
+    val app: MockApp = MockApp(new EchoController)
+
+    val content = "Hello, World!"
+
+    // When
+    val response = app.post("/testing", body = content)
+
+    // Then
+    response.code should be(200)
+    response.body should be(content)
+  }
+
+  "SpecHelper" should "allow us to submit an HTTP body for PUT method" in {
+    val app: MockApp = MockApp(new EchoController)
+
+    val content = "Hello, World!"
+
+    // When
+    val response = app.put("/testing", body = content)
+
+    // Then
+    response.code should be(200)
+    response.body should be(content)
+  }
+
+  /*
+   According to http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html, the OPTIONS
+   method can support an entity-body.
+   */
+  "SpecHelper" should "allow us to submit an HTTP body for OPTIONS method" in {
+    val app: MockApp = MockApp(new EchoController)
+
+    val content = "Hello, World!"
+
+    // When
+    val response = app.options("/testing", body = content)
+
+    // Then
+    response.code should be(200)
+    response.body should be(content)
+  }
 }


### PR DESCRIPTION
When testing via SpecHelper, there was no way to specify the body of POST, PUT or OPTIONS methods.
