### PR TITLE
Add content-length: 0 for no content responses

### DIFF
--- a/src/main/scala/com/twitter/finatra/ResponseBuilder.scala
+++ b/src/main/scala/com/twitter/finatra/ResponseBuilder.scala
@@ -85,7 +85,7 @@ class ResponseBuilder {
                   case Some(bb) =>
                     resp.headers.set("Content-Length", bb.length)
                     resp.setContent(copiedBuffer(bb))
-                  case None => resp // no-op
+                  case None => resp.headers.set("Content-Length", 0) //no content
                 }
             }
         }

--- a/src/test/scala/com/twitter/finatra/ResponseBuilderSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ResponseBuilderSpec.scala
@@ -24,23 +24,29 @@ class MockView(val title:String) extends View {
   val template = "mock.mustache"
 }
 
-class ResponseSpec extends ShouldSpec {
+class ResponseBuilderSpec extends ShouldSpec {
   def resp = new ResponseBuilder
   def view = new MockView("howdy view")
 
   ".ok" should "return a 200 response" in {
-    resp.ok.build
-      .statusCode should equal(200)
+    val built = resp.ok.build
+
+    built.statusCode should equal(200)
+    built.headerMap.get("Content-Length").get.toInt should equal (0)
   }
 
   ".notFound" should "return a 404 response" in {
-    resp.notFound.build
-      .statusCode should equal (404)
+    val built = resp.notFound.build
+
+    built.statusCode should equal (404)
+    built.headerMap.get("Content-Length").get.toInt should equal (0)
   }
 
   ".status(201)" should "return a 201 response" in {
-    resp.status(201).build
-      .statusCode should equal (201)
+    val built = resp.status(201).build
+
+    built.statusCode should equal (201)
+    built.headerMap.get("Content-Length").get.toInt should equal (0)
   }
 
   ".plain()" should "return a 200 plain response" in {


### PR DESCRIPTION
- adds `Content-Length: 0` header to no content responses

In the current version content length header is not added if there isn't any content in the response. This behaviour creates a problem when accessing finatra application through an nginx proxy server. Since application doesn't send length data, the proxy server keeps the connection open until it times out. This results into long response times for responses to option requests, 301 responses etc.

[Here](https://github.com/grandbora/finatra-test-app/blob/master/TestApp/src/main/scala/com/sc/TestApp/App.scala#L20-L31) I created two endpoints where the difference can be observed. Although when accessed from browser both endpoints behaves the same (and fine), when accessed via curl the behaviour is different. On the `/redirect-without-header` endpoint curl hangs [forever](http://cdn2.scratch.mit.edu/get_image/gallery/256731_170x100.png?v=1380430516.91).

cc @pcalcado @streadway
