### PR TITLE
maxRequestSize flag has no effect

### DIFF
--- a/src/main/scala/com/twitter/finatra/FinatraServer.scala
+++ b/src/main/scala/com/twitter/finatra/FinatraServer.scala
@@ -59,7 +59,6 @@ class FinatraServer extends FinatraTwitterServer {
       service(FinagleRequest(req)) map { _.httpResponse }
     }
 
-
   private[this] lazy val service = {
     val appService  = new AppService(controllers)
     val fileService = new FileService
@@ -71,7 +70,7 @@ class FinatraServer extends FinatraTwitterServer {
     nettyToFinagle andThen allFilters(appService)
   }
 
-  private[this] val codec = {
+  private[this] lazy val codec = {
     http.Http()
       .maxRequestSize(config.maxRequestSize().megabyte)
       .enableTracing(true)


### PR DESCRIPTION
maxRequestSize flag has no effect because codec gets initialized when FinatraServer object is loaded and hence uses only the default value of 5MB - fix is to make codec lazy val
