### PR TITLE
mixing Router with Twitter App creates exitTimer thread per request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "finatra"
 
 organization := "com.twitter"
 
-version := "1.5.3"
+version := "1.5.4-SNAPSHOT"
 
 scalaVersion := "2.10.3"
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.twitter</groupId>
   <artifactId>finatra</artifactId>
-  <version>1.5.3</version>
+  <version>1.5.4-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <description>Sinatra clone on top of finagle-http</description>
   <inceptionYear>2012</inceptionYear>

--- a/src/main/scala/com/twitter/finatra/Controller.scala
+++ b/src/main/scala/com/twitter/finatra/Controller.scala
@@ -46,8 +46,8 @@ class Controller extends App with Logging with Stats {
 
   val stats = statsReceiver.scope("Controller")
 
-  def render: ResponseBuilder  = new ResponseBuilder
-  def route:  Router    = new Router(this)
+  def render: ResponseBuilder = new ResponseBuilder
+  def route: Router = new Router(this)
 
   def redirect(location: String, message: String = "", permanent: Boolean = false): ResponseBuilder = {
     val msg = if (message == "")

--- a/src/main/scala/com/twitter/finatra/Router.scala
+++ b/src/main/scala/com/twitter/finatra/Router.scala
@@ -8,7 +8,7 @@ import com.twitter.util.Future
 import com.twitter.app.App
 import org.jboss.netty.util.CharsetUtil
 
-class Router(controller: Controller) extends App with Logging {
+class Router(controller: Controller) {
 
   def dispatch(request: FinagleRequest): Option[Future[FinagleResponse]] = {
     dispatchRouteOrCallback(request, request.method, (request) => {


### PR DESCRIPTION
mixing Router with Twitter App creates exitTimer thread per request

See: https://github.com/twitter/util/blob/master/util-app/src/main/scala/com/twitter/app/App.scala#L63

I also think `def route` should be `val route`
