### PR TITLE
Pass the filename of the template to the factory

### DIFF
--- a/src/main/scala/com/twitter/finatra/View.scala
+++ b/src/main/scala/com/twitter/finatra/View.scala
@@ -86,7 +86,7 @@ abstract class View extends Callable[String] {
   var baseTemplatePath: String        = View.templatePath
   var contentType: Option[String]     = None
   def mustache: Mustache              = factory.compile(
-    new InputStreamReader(FileResolver.getInputStream(templatePath)), "template"
+    new InputStreamReader(FileResolver.getInputStream(templatePath)), template
   )
 
   def render: String = {


### PR DESCRIPTION
Mustache uses the file's extension when resolving partials, so it's important that the actual file name is used.
