### PR TITLE
Don't add .mustache extension to template file name if it already has an extension

### DIFF
--- a/src/main/scala/com/twitter/finatra/View.scala
+++ b/src/main/scala/com/twitter/finatra/View.scala
@@ -35,7 +35,7 @@ class FinatraMustacheFactory(baseTemplatePath:String) extends DefaultMustacheFac
     // system and avoid using the classloader which has
     // priority in DefaultMustacheFactory.getReader
     else {
-      val fileName = if (resourceName contains ".mustache") resourceName else resourceName+".mustache"
+      val fileName = if (resourceName contains ".") resourceName else resourceName+".mustache"
       val basePath = combinePaths(config.docRoot(), config.templatePath())
       val file:File = new File(basePath, fileName)
 


### PR DESCRIPTION
It's reasonable to want to have "home.html" be a mustache template, for example. The current logic will turn that into "home.html.mustache" in development but not in production.
