### PR TITLE
Fix for mustache templates that don't load in production environments.

### DIFF
--- a/src/test/scala/com/twitter/finatra/ViewSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ViewSpec.scala
@@ -19,4 +19,17 @@ class ViewSpec extends ShouldSpec {
     view.render should include ("please &lt;escape&gt; me")
     view.render should include ("<div>") // prove we don't escape the partial's content
   }
+
+  "A layout" should "render in production mode" in {
+    System.setProperty("com.twitter.finatra.config.env", "production")
+    try {
+      val posts = List(new Post("One"), new Post("Two"))
+      val view  = new PostsListView(posts)
+
+      view.render should include ("Hello World")
+      view.render should include ("This is Base.")
+    } finally {
+      System.setProperty("com.twitter.finatra.config.env", "development")
+    }
+  }
 }


### PR DESCRIPTION
Nested templates will NOT have the '.mustache' file extension which
means they will not load. In addition, FileResolver already handles
development/production environment loading strategies properly and
is already used by the View class, so we should use it in the
FinatraMustacheFactory as well.
