### PR TITLE
use path from the request object to created stats per expanded route

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "finatra"
 
 organization := "com.twitter"
 
-version := "1.5.4"
+version := "1.5.4-SNAPSHOT"
 
 scalaVersion := "2.10.3"
 

--- a/src/main/scala/com/twitter/finatra/RequestAdapter.scala
+++ b/src/main/scala/com/twitter/finatra/RequestAdapter.scala
@@ -17,6 +17,7 @@ package com.twitter.finatra
 
 import com.twitter.finagle.http.{Request => FinagleRequest}
 import org.jboss.netty.handler.codec.http.HttpMethod
+import org.jboss.netty.handler.codec.http.multipart.HttpPostRequestDecoder
 
 /**
 * Adapts a FinagleRquest to a FinatraRequest
@@ -28,7 +29,7 @@ object RequestAdapter {
 
     request.getContent.markReaderIndex
 
-    if (request.method == HttpMethod.POST) {
+    if (request.method == HttpMethod.POST && HttpPostRequestDecoder.isMultipart(request)) {
       request.multiParams = MultipartParsing(request)
     }
 


### PR DESCRIPTION
path arg to addRoute is a regex pattern. Creating stats with regex lumps all routes that match the same regex under the same name. This might be undesirable in scenarios where you want finer grained stats per dynamic route. Use path from Request object, instead of regex pattern 
