### PR TITLE
Session Support

### DIFF
--- a/src/main/scala/com/twitter/finatra/Session.scala
+++ b/src/main/scala/com/twitter/finatra/Session.scala
@@ -68,5 +68,5 @@ private object DefaultSessionHolder extends SessionHolder {
     sessions.remove(c)
   }
 
-  override def getOrCreateSession(c: SessionCookie) = sessions.getOrElse(c, createAndAddSession(c))
+  override def getOrCreateSession(c: SessionCookie): Session = sessions.getOrElse(c, createAndAddSession(c))
 }

--- a/src/main/scala/com/twitter/finatra/Session.scala
+++ b/src/main/scala/com/twitter/finatra/Session.scala
@@ -1,0 +1,55 @@
+package com.twitter.finatra
+
+import java.util.UUID
+import com.twitter.finagle.http.Cookie
+import scala.collection.mutable
+
+trait SessionEnabled {
+  def session(implicit req: Request): Session = {
+    val sessionCookie: SessionCookie = req.cookies.get("_session_id") match {
+      case None    => SessionCookie()
+      case Some(c) => SessionCookie(c.value)
+    }
+
+    req.response.addCookie(sessionCookie)
+    SessionHolder.getOrCreateSession(sessionCookie)
+  }
+}
+
+object SessionCookie {
+  def apply() = new SessionCookie(newSessionId)
+
+  def apply(value: String) = new SessionCookie(value)
+
+  private def newSessionId = UUID.randomUUID.toString
+}
+
+case class SessionCookie(cookieValue: String, isHttpOnly: Boolean = true, secure: Boolean = false)
+  extends Cookie("_session_id", cookieValue) {
+
+  override def httpOnly = isHttpOnly
+
+  override def isSecure = secure
+}
+
+protected class Session(val sessionId: String) {
+  private val values = mutable.Map[String, String]()
+
+  def get(key: String): Option[String] = values.get(key)
+
+  def put(key: String, value: String) {
+    values(key) = value
+  }
+}
+
+object SessionHolder {
+  private val sessions = mutable.Map[SessionCookie, Session]()
+
+  private def createAndAddSession(c: SessionCookie) = {
+    val context = new Session(c.value)
+    sessions(c) = context
+    context
+  }
+
+  def getOrCreateSession(c: SessionCookie) = sessions.getOrElse(c, createAndAddSession(c))
+}

--- a/src/main/scala/com/twitter/finatra/Session.scala
+++ b/src/main/scala/com/twitter/finatra/Session.scala
@@ -37,6 +37,8 @@ protected class Session(val sessionId: String) {
 
   def get(key: String): Option[String] = values.get(key)
 
+  def getOrElse(key: String, default: String): String = values.getOrElse(key, default)
+
   def put(key: String, value: String) {
     values(key) = value
   }

--- a/src/test/scala/com/twitter/finatra/SessionSpec.scala
+++ b/src/test/scala/com/twitter/finatra/SessionSpec.scala
@@ -1,0 +1,48 @@
+package com.twitter.finatra
+
+import com.twitter.finatra.test.FlatSpecHelper
+
+class SessionEnabledApp extends Controller with SessionEnabled {
+
+  get("/new_session") { implicit request =>
+    session.put("foo", "bar")
+    render.plain("wooo").toFuture
+  }
+
+  get("/existing_session") { implicit request =>
+    render.plain(session.get("foo").getOrElse("<empty>")).toFuture
+  }
+}
+
+class SessionSpec extends FlatSpecHelper {
+
+  val server = new FinatraServer
+  server.register(new SessionEnabledApp)
+
+  "basic session creation" should "have _session_id set" in {
+    get("/new_session")
+    response.getHeader("Set-Cookie") should startWith("_session_id=")
+  }
+
+  "session retrieve" should "retrieve an existing session for a given _session_id" in {
+    val session = SessionHolder.getOrCreateSession(SessionCookie("TEST_SESSION_ID"))
+    session.put("foo", "bar")
+    get("/existing_session", headers = Map("Cookie" -> "_session_id=TEST_SESSION_ID"))
+    response.body should be("bar")
+  }
+
+  "#get" should "retrieve Some(value) or None" in {
+    val session = new Session("TEST_SESSION_ID")
+    session.get("nothing") should be(None)
+    session.put("foo", "bar")
+    session.get("foo") should be(Some("bar"))
+  }
+
+  "#put" should "set or update values in session" in {
+    val session = new Session("TEST_SESSION_ID")
+    session.put("foo", "bar")
+    session.get("foo") should be(Some("bar"))
+    session.put("foo", "xyz")
+    session.get("foo") should be(Some("xyz"))
+  }
+}

--- a/src/test/scala/com/twitter/finatra/SessionSpec.scala
+++ b/src/test/scala/com/twitter/finatra/SessionSpec.scala
@@ -10,7 +10,7 @@ class SessionEnabledApp extends Controller with SessionEnabled {
   }
 
   get("/existing_session") { implicit request =>
-    render.plain(session.get("foo").getOrElse("<empty>")).toFuture
+    render.plain(session.getOrElse("foo", "<empty>")).toFuture
   }
 }
 


### PR DESCRIPTION
Enables session support in a way that you can specify it whenever you need it

```scala
class SessionController extends Controller with SessionEnabled {

  get("/") { implicit request =>
    session.put("foo", "bar")
    render.plain("wooo").toFuture
  }

  get("/value") { implicit request =>
    render.plain(session.get("foo").getOrElse("nothing")).toFuture
  }
}
```