### PR TITLE
Bumped twitter-server to 1.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,7 @@ crossScalaVersions := Seq("2.9.2", "2.10.3")
 //Main
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "twitter-server" % "1.6.1",
-  "com.twitter" %% "finagle-stats" % "6.13.1",
+  "com.twitter" %% "twitter-server" % "1.7.1",
   "commons-io" % "commons-io" % "1.3.2",
   "org.scalatest" %% "scalatest" % "1.9.2",
   "com.google.code.findbugs" % "jsr305" % "2.0.1",

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>twitter-server_2.10</artifactId>
-      <version>1.6.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.twitter</groupId>
-      <artifactId>finagle-stats_2.10</artifactId>
-      <version>6.13.1</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
We need (kinda urgently) Finagle 6.17+ to use new MySQL things, and also just because it's not good to be so behind in bugfixes and etc.

I've tested this patch with our internal applications, everything compiles and works fine.

//cc @fwbrasil @grandbora @folone @salomvary @codemanki
