### PR TITLE
Adding missing copyright headers to source files

### DIFF
--- a/src/main/scala/com/twitter/finatra/AdminHttpServer.scala
+++ b/src/main/scala/com/twitter/finatra/AdminHttpServer.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.app.App

--- a/src/main/scala/com/twitter/finatra/ContentType.scala
+++ b/src/main/scala/com/twitter/finatra/ContentType.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 object ContentType {

--- a/src/main/scala/com/twitter/finatra/ControllerCollection.scala
+++ b/src/main/scala/com/twitter/finatra/ControllerCollection.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finagle.http.{Request => FinagleRequest, Response => FinagleResponse}

--- a/src/main/scala/com/twitter/finatra/ErrorHandler.scala
+++ b/src/main/scala/com/twitter/finatra/ErrorHandler.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.app.App

--- a/src/main/scala/com/twitter/finatra/FileService.scala
+++ b/src/main/scala/com/twitter/finatra/FileService.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finagle.{Service, SimpleFilter}

--- a/src/main/scala/com/twitter/finatra/FinatraTwitterServer.scala
+++ b/src/main/scala/com/twitter/finatra/FinatraTwitterServer.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.app.App

--- a/src/main/scala/com/twitter/finatra/Logging.scala
+++ b/src/main/scala/com/twitter/finatra/Logging.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 

--- a/src/main/scala/com/twitter/finatra/LoggingFilter.scala
+++ b/src/main/scala/com/twitter/finatra/LoggingFilter.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finagle.{Service, SimpleFilter}

--- a/src/main/scala/com/twitter/finatra/PathParser.scala
+++ b/src/main/scala/com/twitter/finatra/PathParser.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 /**

--- a/src/main/scala/com/twitter/finatra/RouteVector.scala
+++ b/src/main/scala/com/twitter/finatra/RouteVector.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 class RouteVector[A] {

--- a/src/main/scala/com/twitter/finatra/Router.scala
+++ b/src/main/scala/com/twitter/finatra/Router.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finagle.http.{Request => FinagleRequest, Response => FinagleResponse}

--- a/src/main/scala/com/twitter/finatra/config/Config.scala
+++ b/src/main/scala/com/twitter/finatra/config/Config.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra.config
 
 import com.twitter.app.GlobalFlag

--- a/src/test/scala/com/twitter/finatra/FileServiceSpec.scala
+++ b/src/test/scala/com/twitter/finatra/FileServiceSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finatra.test.ShouldSpec

--- a/src/test/scala/com/twitter/finatra/FileSpec.scala
+++ b/src/test/scala/com/twitter/finatra/FileSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import test.ShouldSpec

--- a/src/test/scala/com/twitter/finatra/LayoutViewSpec.scala
+++ b/src/test/scala/com/twitter/finatra/LayoutViewSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra.test
 
 

--- a/src/test/scala/com/twitter/finatra/LoggingSpec.scala
+++ b/src/test/scala/com/twitter/finatra/LoggingSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import test.ShouldSpec

--- a/src/test/scala/com/twitter/finatra/Mocks.scala
+++ b/src/test/scala/com/twitter/finatra/Mocks.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra.test
 
 import com.twitter.finatra.View

--- a/src/test/scala/com/twitter/finatra/MultipartUploadSpec.scala
+++ b/src/test/scala/com/twitter/finatra/MultipartUploadSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finatra.test.FlatSpecHelper

--- a/src/test/scala/com/twitter/finatra/RequestResponseSpec.scala
+++ b/src/test/scala/com/twitter/finatra/RequestResponseSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finatra.test.FlatSpecHelper

--- a/src/test/scala/com/twitter/finatra/RequestSpec.scala
+++ b/src/test/scala/com/twitter/finatra/RequestSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import test.ShouldSpec

--- a/src/test/scala/com/twitter/finatra/RouteParamsSpec.scala
+++ b/src/test/scala/com/twitter/finatra/RouteParamsSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra
 
 import com.twitter.finatra.test.{FlatSpecHelper, SpecHelper}

--- a/src/test/scala/com/twitter/finatra/ViewSpec.scala
+++ b/src/test/scala/com/twitter/finatra/ViewSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.twitter.finatra.test
 
 class ViewSpec extends ShouldSpec {


### PR DESCRIPTION
Many source files in finatra don't have the standard copyright header on them - adding these.
