### PR TITLE
Do not log errors in the ErrorHandler

### DIFF
--- a/src/main/scala/com/twitter/finatra/ErrorHandler.scala
+++ b/src/main/scala/com/twitter/finatra/ErrorHandler.scala
@@ -5,7 +5,6 @@ import com.twitter.app.App
 object ErrorHandler extends App with Logging {
 
   def apply(request: Request, e: Throwable, controllers: ControllerCollection) = {
-    log.error(e, "Internal Server Error", Nil)
     request.error = Some(e)
     ResponseAdapter(request, controllers.errorHandler(request))
   }


### PR DESCRIPTION
This change is to suppress excessive logging for exceptions that are captured and handled correctly downstream. Specifically, we're following the [conventions suggested in the documentation](http://finatra.info/docs/index.html#routing) by using an error handler to respond to certain requests a 404 NOT FOUND. Because of the `log.error()` in this method, a full stacktrace is printed to the logs with the message "Internal Server Error" even though it's not really an internal error.