### PR TITLE
Fix heroku deployments for template project

### DIFF
--- a/script/finatra/libexec/finatra-new
+++ b/script/finatra/libexec/finatra-new
@@ -135,9 +135,6 @@ sed -ie "s/###PROJECT_NAME###/$project_name/g" $root_path/$project_name/README.m
 #edit build.sbt
 sed -ie "s/###PROJECT_NAME###/$project_name/g" $root_path/$project_name/build.sbt
 
-#edit assembly.sbt
-sed -ie "s/###PROJECT_NAME###/$project_name/g" $root_path/$project_name/assembly.sbt
-
 if [ $snapshot_version ]; then
   sed -ie "s/###VERSION###/$snapshot_version/g" $root_path/$project_name/pom.xml
 else
@@ -155,7 +152,6 @@ rm -rf $root_path/$project_name/pom.xmle
 rm -rf $root_path/$project_name/README.markdowne
 rm -rf $root_path/$project_name/build.sbte
 rm -rf $root_path/$project_name/bower.jsone
-rm -rf $root_path/$project_name/assembly.sbte
 rm -rf $dest_path/App.scalae
 rm -rf $root_path/$project_name/Procfilee
 rm -rf $test_path/AppSpec.scalae

--- a/script/finatra/libexec/finatra-new
+++ b/script/finatra/libexec/finatra-new
@@ -59,10 +59,10 @@ echo "  creating build.sbt"
 cp $_FINATRA_ROOT/share/build.sbt $root_path/$project_name/
 echo "  creating build.properties"
 cp $_FINATRA_ROOT/share/build.properties $root_path/$project_name/project
-echo "  creating project/assembly.sbt"
-cp $_FINATRA_ROOT/share/assembly_plugin.sbt $root_path/$project_name/project
-echo "  creating assembly.sbt"
-cp $_FINATRA_ROOT/share/assembly.sbt $root_path/$project_name/
+echo "  creating project/plugins.sbt"
+cp $_FINATRA_ROOT/share/plugins.sbt $root_path/$project_name/project
+echo "  creating .env"
+cp $_FINATRA_ROOT/share/dot-env $root_path/$project_name/.env
 echo "  creating README"
 cp $_FINATRA_ROOT/share/README.markdown $root_path/$project_name/
 echo "  creating Procfile"
@@ -115,6 +115,7 @@ sed -ie "s/###PROJECT_NAME###/$project_name/g" $root_path/$project_name/bower.js
 
 # edit Procfile
 sed -ie "s/###PACKAGE_NAME###/$package_name/g" $root_path/$project_name/Procfile
+sed -ie "s/###PROJECT_NAME###/$project_name/g" $root_path/$project_name/Procfile
 
 # replace the spec with the latest example spec
 replace_with_example_spec $_FINATRA_ROOT/share/AppSpec.scala $test_path/AppSpec.scala

--- a/script/finatra/share/Procfile
+++ b/script/finatra/share/Procfile
@@ -1,1 +1,1 @@
-web:    java -Dcom.twitter.finatra.config.env=production -Dcom.twitter.finatra.config.adminPort='' -Dcom.twitter.finatra.config.port=:$PORT -cp target/classes:target/dependency/* ###PACKAGE_NAME###.App
+web: target/universal/stage/bin/###PROJECT_NAME### -Dcom.twitter.finatra.config.env=$ENV -Dcom.twitter.finatra.config.adminPort=$ADMIN_PORT -Dcom.twitter.finatra.config.port=:$PORT

--- a/script/finatra/share/README.markdown
+++ b/script/finatra/share/README.markdown
@@ -43,9 +43,12 @@ You may also need to install foreman:
 
 ### To put on heroku
 
+    heroku login
+    git init
     heroku create --buildpack https://github.com/heroku/heroku-buildpack-scala.git
     heroku config:set ENV=production
-    heroku config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-scala
+    git add .
+    git commit -am "Initial commit"
     git push heroku master
 
 ### To run locally like it does on heroku

--- a/script/finatra/share/README.markdown
+++ b/script/finatra/share/README.markdown
@@ -44,6 +44,7 @@ You may also need to install foreman:
 ### To put on heroku
 
     heroku create
+    heroku config:set ENV=production
     git push heroku master
 
 ### To run locally like it does on heroku

--- a/script/finatra/share/README.markdown
+++ b/script/finatra/share/README.markdown
@@ -2,6 +2,9 @@
 
 Finatra requires either [maven](http://maven.apache.org/) or [sbt](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html) to build and run your app.
 
+The `.env` file is used to configure Heroku environment variables locally. See [heroku's docs](https://devcenter.heroku.com/articles/config-vars) for more information. *Do not check it into source control!*.
+
+
 ## SBT Instructions
 
 ### Runs your app on port 7070
@@ -12,10 +15,9 @@ Finatra requires either [maven](http://maven.apache.org/) or [sbt](http://www.sc
 
     sbt test
 
-### Packaging (fatjar)
+### Packaging
 
-    sbt assembly
-
+    sbt stage
 
 ## Maven Instructions
 
@@ -31,14 +33,24 @@ Finatra requires either [maven](http://maven.apache.org/) or [sbt](http://www.sc
 
     mvn package
 
-
 ## Heroku
+
+Install [heroku toolbelt](https://toolbelt.heroku.com/).
+
+You may also need to install foreman:
+
+    gem install foreman
 
 ### To put on heroku
 
     heroku create
     git push heroku master
 
+### To run locally like it does on heroku
+
+    foreman start web
+
 ### To run anywhere else
 
-    java -jar target/*-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+    ./target/universal/stage/bin/<appname>
+    

--- a/script/finatra/share/README.markdown
+++ b/script/finatra/share/README.markdown
@@ -43,7 +43,7 @@ You may also need to install foreman:
 
 ### To put on heroku
 
-    heroku create
+    heroku create --buildpack https://github.com/heroku/heroku-buildpack-scala.git
     heroku config:set ENV=production
     heroku config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-scala
     git push heroku master

--- a/script/finatra/share/README.markdown
+++ b/script/finatra/share/README.markdown
@@ -45,6 +45,7 @@ You may also need to install foreman:
 
     heroku create
     heroku config:set ENV=production
+    heroku config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-scala
     git push heroku master
 
 ### To run locally like it does on heroku

--- a/script/finatra/share/assembly.sbt
+++ b/script/finatra/share/assembly.sbt
@@ -1,5 +1,0 @@
-import AssemblyKeys._
-
-assemblySettings
-
-outputPath in assembly := new File("target/###PROJECT_NAME###-0.0.1-SNAPSHOT-jar-with-dependencies.jar")

--- a/script/finatra/share/assembly_plugin.sbt
+++ b/script/finatra/share/assembly_plugin.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.10.2")

--- a/script/finatra/share/build.properties
+++ b/script/finatra/share/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.6

--- a/script/finatra/share/build.properties
+++ b/script/finatra/share/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.5

--- a/script/finatra/share/build.sbt
+++ b/script/finatra/share/build.sbt
@@ -1,8 +1,12 @@
+import NativePackagerKeys._
+
+packageArchetype.java_application
+
 name := "###PROJECT_NAME###"
 
 version := "0.0.1-SNAPSHOT"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finatra" % "###VERSION###"

--- a/script/finatra/share/dot-env
+++ b/script/finatra/share/dot-env
@@ -1,0 +1,3 @@
+PORT=7070
+ADMIN_PORT=:9990
+ENV=development

--- a/script/finatra/share/plugins.sbt
+++ b/script/finatra/share/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-RC1")


### PR DESCRIPTION
As per issue https://github.com/twitter/finatra/issues/180

The included deployment (well, the assembly plugin) does not work against heroku. In short, heroku expects to call `stage` and the shipped plugin uses `assembly`:

I made a few changes to get it working:

1. Added the native packager plugin to `project/plugins.sbt`

        addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0-RC1")

1. Removed the `assembly_plugin.sbt` file.

1. Added the necessary references to build.sbt

        import NativePackagerKeys._
        packageArchetype.java_application

1. Changed procfile as follows:

        web: target/universal/stage/bin/<appname> -Dcom.twitter.finatra.config.env=$ENV -Dcom.twitter.finatra.config.adminPort=$ADMIN_PORT -Dcom.twitter.finatra.config.port=:$PORT

Notes.

1. I added the `$ADMIN_PORT` environment variable so I can run `formate start` on the local command line to have the app boot via the `Procfile`.

1. I added `$ENV` for the same reason, so that the `development` or whatever environment can be passed locally while still using the production style startup process.

1. These require a `.env` file with those parameters defined as follows:

        PORT=7070
        ADMIN_PORT=:9990
        ENV=development
