### PR TITLE
Update to use new Travis CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
+sudo: false
 script:
   - sbt test
   - sbt coveralls
 scala:
   - 2.9.2
-  - 2.10.0
+  - 2.10.4


### PR DESCRIPTION
Should speed up builds a bit. Also use 2.10.4 for Scala.

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Signed-off-by: Chris Aniszczyk zx@twitter.com
