### PR TITLE
allow EmbeddedHttpServer.httpPatch() to send body

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -687,6 +687,7 @@ class DoEverythingServerFeatureTest extends FeatureTest {
     "patch" in {
       server.httpPatch(
         "/patch",
+        patchBody = "asdf",
         andExpect = Ok,
         withBody = "patch")
     }

--- a/http/src/test/scala/com/twitter/finatra/http/test/EmbeddedHttpServer.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/test/EmbeddedHttpServer.scala
@@ -273,9 +273,10 @@ class EmbeddedHttpServer(
 
   def httpPatch(
     path: String,
+    patchBody: String,
     accept: MediaType = null,
-    headers: Map[String, String] = Map(),
     suppress: Boolean = false,
+    headers: Map[String, String] = Map(),
     andExpect: HttpResponseStatus = Status.Ok,
     withLocation: String = null,
     withBody: String = null,
@@ -286,7 +287,29 @@ class EmbeddedHttpServer(
     secure: Option[Boolean] = None): Response = {
 
     val request = createApiRequest(path, HttpMethod.PATCH)
+    request.setContentString(patchBody)
+    request.headers().set(HttpHeaders.CONTENT_LENGTH, patchBody.length)
+
     jsonAwareHttpExecute(request, addAcceptHeader(accept, headers), suppress, andExpect, withLocation, withBody, withJsonBody, withJsonBodyNormalizer, withErrors, routeToAdminServer, secure = secure.getOrElse(defaultHttpSecure))
+  }
+
+  def httpPatchJson[ResponseType: Manifest](
+    path: String,
+    patchBody: String,
+    suppress: Boolean = false,
+    headers: Map[String, String] = Map(),
+    andExpect: HttpResponseStatus = Status.Ok,
+    withLocation: String = null,
+    withBody: String = null,
+    withJsonBody: String = null,
+    withJsonBodyNormalizer: JsonNode => JsonNode = null,
+    normalizeJsonParsedReturnValue: Boolean = false,
+    withErrors: Seq[String] = null,
+    routeToAdminServer: Boolean = false,
+    secure: Option[Boolean] = None): ResponseType = {
+
+    val response = httpPatch(path, patchBody, MediaType.JSON_UTF_8, suppress, headers, andExpect, withLocation, withBody, withJsonBody, withJsonBodyNormalizer, withErrors, routeToAdminServer, secure)
+    jsonParseWithNormalizer(response, withJsonBodyNormalizer, normalizeJsonParsedReturnValue)
   }
 
   def httpHead(


### PR DESCRIPTION
very minor change, making `EmbeddedHttpServer.httpPatch()` work analogously to  `EmbeddedHttpServer.httpPut()`