### PR TITLE
Fix typo in finatra-http's README

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -4,7 +4,7 @@ Finatra HTTP Overview
 Quick Start
 -----------------------------------------------------------
 * Depend on the `com.twitter.finatra:finatra-http` library.
-* We also recommend depending on `com.twitter.finatra:finatra-slf4j` and `ch.qos.logback:logback-classic` to choose [Logback][logback] as your [slf4j](http://www.slf4j.org/manual.html) implementation.
+* We also recommend depending on `com.twitter.finatra:finatra-logback` and `ch.qos.logback:logback-classic` to choose [Logback][logback] as your [slf4j](http://www.slf4j.org/manual.html) implementation.
 * See the [finatra-hello-world](../examples/finatra-hello-world) example.
 * See also [todo list example][quick-start].
 


### PR DESCRIPTION
Hiya,

I may be missing something but looking at the [published repositories](https://oss.sonatype.org/content/repositories/releases/com/twitter/finatra/) there is no `finatra-slf4j`. I think it should be `finatra-logback`

Cheers