### PR TITLE
Add support for @JsonDeserialize in case class fields

### DIFF
--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassField.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassField.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.{JsonParser, ObjectCodec}
+import com.fasterxml.jackson.core.ObjectCodec
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
@@ -113,7 +113,7 @@ class FinatraCaseClassDeserializer(
 
     for (field <- caseClassFields) {
       try {
-        val value = field.parse(context, jp.getCodec, jsonNode)
+        val value = field.parse(context, jp, jsonNode)
         addConstructorValue(value)
 
         if (field.validationAnnotations.nonEmpty) {

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
@@ -113,7 +113,7 @@ class FinatraCaseClassDeserializer(
 
     for (field <- caseClassFields) {
       try {
-        val value = field.parse(context, jp, jsonNode)
+        val value = field.parse(context, jp.getCodec, jsonNode)
         addConstructorValue(value)
 
         if (field.validationAnnotations.nonEmpty) {

--- a/jackson/src/test/scala/com/twitter/finatra/tests/json/FinatraObjectMapperTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/tests/json/FinatraObjectMapperTest.scala
@@ -853,6 +853,15 @@ class FinatraObjectMapperTest extends FeatureSpec with Matchers with Logging {
         "foo's value 'bar' is not a valid boolean"))
   }
 
+  feature("jackson JsonDeserialize annotations") {
+    scenario("deserializes json to case class with 2 decimal places") {
+      parse[CaseClassWithCustomDecimalFormat](
+        """ {
+            "my_big_decimal": 23.1201
+          }""") should equal(CaseClassWithCustomDecimalFormat(BigDecimal(23.12)))
+    }
+  }
+
   private def assertJsonParse[T: Manifest](json: String, withErrors: Seq[String]) = {
     if (withErrors.nonEmpty) {
       val e1 = intercept[JsonObjectParseException] {

--- a/jackson/src/test/scala/com/twitter/finatra/tests/json/FinatraObjectMapperTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/tests/json/FinatraObjectMapperTest.scala
@@ -854,11 +854,18 @@ class FinatraObjectMapperTest extends FeatureSpec with Matchers with Logging {
   }
 
   feature("jackson JsonDeserialize annotations") {
-    scenario("deserializes json to case class with 2 decimal places") {
+    scenario("deserializes json to case class with 2 decimal places for mandatory field") {
       parse[CaseClassWithCustomDecimalFormat](
         """ {
             "my_big_decimal": 23.1201
-          }""") should equal(CaseClassWithCustomDecimalFormat(BigDecimal(23.12)))
+          }""") should equal(CaseClassWithCustomDecimalFormat(BigDecimal(23.12), None))
+    }
+    scenario("deserializes json to case class with 2 decimal places for option field") {
+      parse[CaseClassWithCustomDecimalFormat](
+        """ {
+            "my_big_decimal": 23.1201,
+            "opt_my_big_decimal": 23.1201
+          }""") should equal(CaseClassWithCustomDecimalFormat(BigDecimal(23.12), Some(BigDecimal(23.12))))
     }
   }
 

--- a/jackson/src/test/scala/com/twitter/finatra/tests/json/internal/ExampleCaseClasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/tests/json/internal/ExampleCaseClasses.scala
@@ -264,7 +264,9 @@ case class CaseClassWithBoolean(foo: Boolean)
 
 case class CaseClassWithCustomDecimalFormat(
    @JsonDeserialize(using = classOf[MyBigDecimalDeserializer])
-   myBigDecimal: BigDecimal)
+   myBigDecimal: BigDecimal,
+   @JsonDeserialize(using = classOf[MyBigDecimalDeserializer])
+   optMyBigDecimal: Option[BigDecimal])
 
 
 class MyBigDecimalDeserializer extends JsonDeserializer[BigDecimal] {

--- a/jackson/src/test/scala/com/twitter/finatra/tests/json/internal/ExampleCaseClasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/tests/json/internal/ExampleCaseClasses.scala
@@ -1,13 +1,17 @@
 package com.twitter.finatra.tests.json.internal
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonIgnoreProperties, JsonProperty}
-import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.node.ValueNode
 import com.twitter.finatra.domain.WrappedValue
 import com.twitter.finatra.request._
 import com.twitter.finatra.validation.{NotEmpty, ValidationResult}
 import com.twitter.inject.Logging
 import org.joda.time.DateTime
 import scala.annotation.meta.param
+import scala.math.BigDecimal.RoundingMode
 
 case class CaseClass(id: Long, name: String)
 
@@ -257,3 +261,17 @@ case class CaseClassWithInvalidValidation(
 case class NoConstructorArgs()
 
 case class CaseClassWithBoolean(foo: Boolean)
+
+case class CaseClassWithCustomDecimalFormat(
+   @JsonDeserialize(using = classOf[MyBigDecimalDeserializer])
+   myBigDecimal: BigDecimal)
+
+
+class MyBigDecimalDeserializer extends JsonDeserializer[BigDecimal] {
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): BigDecimal = {
+    val jsonNode: ValueNode = jp.getCodec.readTree(jp)
+    BigDecimal(jsonNode.asText).setScale(2, RoundingMode.HALF_UP)
+  }
+
+  override def getEmptyValue: BigDecimal = BigDecimal(0)
+}


### PR DESCRIPTION
Problem
@JsonDeserialize was ignored while deserializing case classes using FinatraCaseClassDeserializer

Solution

Added an optional JsonDeserializer member to CaseClassField. If defined, CaseClassField uses the deserializer to deserialize case class fields.

Result

@JsonDeserialize is now supported in case class fields.