### PR TITLE
Add content type JSON to httpPut and httpPutJson

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/test/EmbeddedHttpServer.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/test/EmbeddedHttpServer.scala
@@ -184,6 +184,7 @@ class EmbeddedHttpServer(
     putBody: String,
     accept: MediaType = null,
     suppress: Boolean = false,
+    contentType: String = Message.ContentTypeJson,
     headers: Map[String, String] = Map(),
     andExpect: HttpResponseStatus = null,
     withLocation: String = null,
@@ -197,6 +198,7 @@ class EmbeddedHttpServer(
     val request = createApiRequest(path, Method.Put)
     request.setContentString(putBody)
     request.headers().set(HttpHeaders.CONTENT_LENGTH, putBody.length)
+    request.headers.set(HttpHeaders.CONTENT_TYPE, contentType)
 
     jsonAwareHttpExecute(request, addAcceptHeader(accept, headers), suppress, andExpect, withLocation, withBody, withJsonBody, withJsonBodyNormalizer, withErrors, routeToAdminServer, secure = secure.getOrElse(defaultHttpSecure))
   }
@@ -216,7 +218,7 @@ class EmbeddedHttpServer(
     routeToAdminServer: Boolean = false,
     secure: Option[Boolean] = None): ResponseType = {
 
-    val response = httpPut(path, putBody, MediaType.JSON_UTF_8, suppress, headers, andExpect, withLocation, withBody, withJsonBody, withJsonBodyNormalizer, withErrors, routeToAdminServer, secure)
+    val response = httpPut(path, putBody, MediaType.JSON_UTF_8, suppress, Message.ContentTypeJson, headers, andExpect, withLocation, withBody, withJsonBody, withJsonBodyNormalizer, withErrors, routeToAdminServer, secure)
     jsonParseWithNormalizer(response, withJsonBodyNormalizer, normalizeJsonParsedReturnValue)
   }
 


### PR DESCRIPTION
Minor change: `httpPut` and `httpPutJson` in `EmbeddedHttpServer.scala` were previously missing lines to specify the content type as Json by default. As a result, FeatureTests written for httpPut required the insertion of `headers = Map("content-type" -> "application/json")`. Adding these lines gets rid of that extraneous requirement. Hopefully it helps!