### PR TITLE
Update logging module to match finatra-examples

### DIFF
--- a/examples/finatra-hello-world/src/main/scala/com/twitter/hello/HelloWorldServer.scala
+++ b/examples/finatra-hello-world/src/main/scala/com/twitter/hello/HelloWorldServer.scala
@@ -5,12 +5,12 @@ import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.CommonFilters
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.logging.filter.{TraceIdMDCFilter, LoggingMDCFilter}
-import com.twitter.finatra.logging.modules.Slf4jBridgeModule
+import com.twitter.finatra.logging.modules.LogbackModule
 
 object HelloWorldServerMain extends HelloWorldServer
 
 class HelloWorldServer extends HttpServer {
-  override def modules = Seq(Slf4jBridgeModule)
+  override def modules = Seq(LogbackModule)
 
   override def configureHttp(router: HttpRouter) {
     router


### PR DESCRIPTION
This file is out of sync with the one in the [finatra-examples repo](https://github.com/twitter/finatra-examples/blob/master/hello-world/src/main/scala/com/twitter/hello/HelloWorldServer.scala). This causes a confusing compile error.

The same change might also be required in the other examples.