### PR TITLE
Update @RequestInject documentation

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -200,7 +200,7 @@ Notes:
      * `@Header`
      * `@Cookie`
  * Other
-     * `@RequestInject`: Injects the Finagle Http Request
+     * `@RequestInject`: Can be used to Inject the Finagle Http Request or any other Guice managed class.
 
 *Note: HTTP requests with a content-type of application/json, are similarly parsed (but "Request Field" annotations are ignored). See [JSON](#json) section below.*
 


### PR DESCRIPTION
It is not obvious that @RequestInject can actually be used to inject any Guice managed class(not just the finagle HTTP Request) so this patch makes that explicit.