### PR TITLE
Subrouter

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/routing/HttpRouterTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/routing/HttpRouterTest.scala
@@ -1,0 +1,65 @@
+package com.twitter.finatra.http.routing
+
+import com.google.inject.{Injector => GuiceInjector, AbstractModule, Binder, Module}
+import com.twitter.finagle.httpx.{Response, Request, Method}
+import com.twitter.finatra.http.Controller
+import com.twitter.finatra.http.internal.exceptions.ExceptionManager
+import com.twitter.finatra.http.internal.marshalling.{CallbackConverter, MessageBodyManager}
+import com.twitter.finatra.http.internal.routing.Route
+import com.twitter.inject.app.TestInjector
+import com.twitter.inject.{Injector, Test}
+import com.twitter.util.Future
+import org.scalatest.OptionValues
+import org.scalatest.mock.MockitoSugar
+import net.codingwell.scalaguice.typeLiteral
+
+class HttpRouterTest extends Test with OptionValues with MockitoSugar {
+
+  "creates sub route" in {
+    val router = createRouter()
+    val mainRouter = router.add("/foo", router.createSubRouter.add(SubController))
+    mainRouter.routes.exists(_.path == "/foo/bar") shouldBe true
+  }
+
+  "creates sub route from injector" in {
+    val injector = TestInjector(createRouterModule[CustomRouter])
+    createRouter(injector).routes.exists(_.path == "/bar/bar") shouldBe true
+  }
+
+  def createRouter(injector: Injector = Injector(mock[GuiceInjector])) = {
+    new HttpRouter(injector, mock[CallbackConverter], mock[MessageBodyManager], mock[ExceptionManager])
+  }
+
+  def createRouterModule[T <: RoutesProvider: Manifest] = {
+    new AbstractModule {
+      override def configure(): Unit = {
+        bind(classOf[RoutesProvider]).to(typeLiteral[T].getRawType.asInstanceOf[Class[T]])
+      }
+    }
+  }
+}
+
+object SubController extends Controller {
+  get("/bar") {
+    "baz"
+  }
+}
+
+class CustomRouter extends RoutesProvider {
+  override def routes: Seq[Route] = createRoute(Method.Get, "/bar/bar") :: Nil
+
+  def defaultCallback(request: Request) = {
+    Future(Response())
+  }
+
+  def createRoute(method: Method, path: String): Route = {
+    Route(
+      name = "my_endpoint",
+      method = method,
+      path = path,
+      callback = defaultCallback,
+      annotations = Seq(),
+      requestClass = classOf[Request],
+      responseClass = classOf[Response])
+  }
+}

--- a/inject/inject-core/src/main/scala/com/twitter/inject/Injector.scala
+++ b/inject/inject-core/src/main/scala/com/twitter/inject/Injector.scala
@@ -1,7 +1,7 @@
 package com.twitter.inject
 
 import com.google.inject.name.Names
-import com.google.inject.{Injector => GuiceInjector, Key}
+import com.google.inject.{Injector => GuiceInjector, Guice, AbstractModule, Key}
 import java.lang.annotation.{Annotation => JavaAnnotation}
 import net.codingwell.scalaguice.KeyExtensions._
 import net.codingwell.scalaguice._
@@ -26,4 +26,12 @@ case class Injector(
   def instance[T](clazz: Class[T]): T = underlying.getInstance(clazz)
 
   def instance[T](key: Key[T]): T = underlying.getInstance(key)
+
+  def instances[T: Manifest]: Seq[T] = {
+    import collection.JavaConversions._
+    underlying.getBindings.flatMap {
+      case (k, v) if typeLiteral[T].getRawType.isAssignableFrom(k.getTypeLiteral.getRawType) => Some(underlying.getInstance(k).asInstanceOf[T])
+      case _ => None
+    }.toSeq
+  }
 }


### PR DESCRIPTION
Prototype implementation for #211.
HttpRouter now has a method for adding subroutes:

```scala
def add(basePath: String, subRouter: HttpRouter) = {
    routes ++= subRouter.routes.map(r => r.copy(path = basePath + r.path))
    this
}
```

Also, uses provided injector to discover new routes from added modules.
I'd be glad to hear suggestions and work to improve this pr.
