### PR TITLE
Allow custom headers and status in StreamingResponse

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/response/StreamingResponse.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/response/StreamingResponse.scala
@@ -60,6 +60,7 @@ case class StreamingResponse[T](
   def toFutureFinagleResponse: Future[Response] = {
     val response = Response()
     response.setChunked(true)
+    response.setStatusCode(status.code)
     addHeaders(headers, response)
     val writer = response.writer
 

--- a/http/src/main/scala/com/twitter/finatra/http/response/StreamingResponse.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/response/StreamingResponse.scala
@@ -15,8 +15,21 @@ object StreamingResponse {
   private val JsonArraySeparator = Some(Buf.Utf8(","))
   private val JsonArraySuffix = Some(Buf.Utf8("]"))
 
+
   def apply[T](toBuf: T => Buf)(stream: => AsyncStream[T]) = {
-    new StreamingResponse[T](toBuf, asyncStream = stream)
+    new StreamingResponse[T](toBuf = toBuf, asyncStream = stream)
+  }
+
+  def apply[T](status: Status, toBuf: T => Buf)(stream: => AsyncStream[T]) = {
+    new StreamingResponse[T](toBuf = toBuf, status = status, asyncStream = stream)
+  }
+
+  def apply[T](toBuf: T => Buf, headers: Map[String, String])(stream: => AsyncStream[T]) = {
+    new StreamingResponse[T](toBuf = toBuf, headers = headers, asyncStream = stream)
+  }
+
+  def apply[T](toBuf: T => Buf, status: Status, headers: Map[String, String])(stream: => AsyncStream[T]) = {
+    new StreamingResponse[T](status = status, toBuf = toBuf, headers = headers, asyncStream = stream)
   }
 
   def jsonArray[T](
@@ -37,6 +50,7 @@ object StreamingResponse {
 case class StreamingResponse[T](
   toBuf: T => Buf,
   status: Status = Status.Ok,
+  headers: Map[String, String] = Map(),
   prefixOpt: Option[Buf] = None,
   separatorOpt: Option[Buf] = None,
   suffixOpt: Option[Buf] = None,
@@ -46,6 +60,7 @@ case class StreamingResponse[T](
   def toFutureFinagleResponse: Future[Response] = {
     val response = Response()
     response.setChunked(true)
+    addHeaders(headers, response)
     val writer = response.writer
 
     /* Orphan the future which writes to our response thread */
@@ -86,5 +101,11 @@ case class StreamingResponse[T](
     stream.take(1) ++ (stream.drop(1) map { buf =>
       separator.concat(buf)
     })
+  }
+
+  private def addHeaders(headersOpt: Map[String, String], response: Response) = {
+    for((k,v) <- headers) {
+      response.headerMap.add(k, v)
+    }
   }
 }

--- a/http/src/test/scala/com/twitter/finatra/http/integration/tweetexample/main/controllers/TweetsController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/tweetexample/main/controllers/TweetsController.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.http.integration.tweetexample.main.controllers
 
 import com.twitter.concurrent.exp.AsyncStream
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.httpx.{Fields, Status, Request, Response}
 import com.twitter.finatra.http.Controller
 import com.twitter.finatra.http.integration.tweetexample.main.domain.Tweet
 import com.twitter.finatra.http.integration.tweetexample.main.services.TweetsRepository
@@ -33,6 +33,17 @@ class TweetsController @Inject()(
 
   get("/tweets/streaming_custom_tobuf") { request: Request =>
     StreamingResponse(Buf.Utf8.apply) {
+      AsyncStream("A", "B", "C")
+    }
+  }
+
+  get("/tweets/streaming_custom_tobuf_with_custom_headers") { request: Request =>
+    val headers = Map(
+      Fields.ContentType -> "text/event-stream;charset=UTF-8",
+      Fields.CacheControl -> "no-cache, no-store, max-age=0, must-revalidate",
+      Fields.Pragma -> "no-cache")
+
+    StreamingResponse(Buf.Utf8.apply, Status.Created, headers) {
       AsyncStream("A", "B", "C")
     }
   }

--- a/http/src/test/scala/com/twitter/finatra/http/integration/tweetexample/test/TweetsControllerIntegrationTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/tweetexample/test/TweetsControllerIntegrationTest.scala
@@ -1,12 +1,12 @@
 package com.twitter.finatra.http.integration.tweetexample.test
 
-import com.twitter.finagle.httpx.Status
 import com.fasterxml.jackson.databind.JsonNode
+import com.twitter.finagle.httpx.{Fields, Status}
 import com.twitter.finatra.http.integration.tweetexample.main.TweetsEndpointServer
-import com.twitter.finatra.http.test.{HttpTest, EmbeddedHttpServer}
+import com.twitter.finatra.http.test.{EmbeddedHttpServer, HttpTest}
 import com.twitter.finatra.httpclient.RequestBuilder
 import com.twitter.inject.server.FeatureTest
-import com.twitter.util.{Await, Future, FuturePool}
+import com.twitter.util.{Await, Future}
 
 class TweetsControllerIntegrationTest extends FeatureTest with HttpTest {
 
@@ -136,6 +136,21 @@ class TweetsControllerIntegrationTest extends FeatureTest with HttpTest {
       "/tweets/streaming_custom_tobuf",
       andExpect = Status.Ok,
       withBody = "ABC")
+  }
+
+  "get streaming custom toBuf with custom headers" in {
+    val response = server.httpGet(
+      "/tweets/streaming_custom_tobuf_with_custom_headers",
+      andExpect = Status.Created,
+      withBody = "ABC")
+
+      response.headerMap.contains(Fields.ContentType) should equal(true)
+      response.headerMap.get(Fields.ContentType).get should equal("text/event-stream;charset=UTF-8")
+      response.headerMap.contains(Fields.Pragma) should equal(true)
+      response.headerMap.get(Fields.Pragma).get should equal("no-cache")
+      response.headerMap.contains(Fields.CacheControl) should equal(true)
+      response.headerMap.get(Fields.CacheControl).get should equal("no-cache, no-store, max-age=0, must-revalidate")
+
   }
 
   "get streaming manual writes" in {


### PR DESCRIPTION
Hi,

This Pr does basically what the titles says.

It allows to add custom headers and status to the Response in StreamingResponse.

```scala
StreamingResponse(Status.Created, headers, Buf.Utf8.apply) {
      AsyncStream("A", "B", "C")
    }
```

Regards,
Jaume Pinyol