### PR TITLE
Improve error message when @Header field is missing

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/main/controllers/DoEverythingController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/main/controllers/DoEverythingController.scala
@@ -574,6 +574,10 @@ class DoEverythingController @Inject()(
     camelCaseObjectMapper.writeValueAsString(Map("firstName" -> "Bob"))
   }
 
+  post("/createUser") {user: CreateUserRequest =>
+    response.created.location(s"/users/${user.requestId}")
+  }
+
   //needed to avoid colliding with Logging#trace :-/
   trace[Request, String]("/trace") { r: Request =>
     "trace 123"

--- a/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/main/controllers/DoEverythingController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/main/controllers/DoEverythingController.scala
@@ -574,7 +574,7 @@ class DoEverythingController @Inject()(
     camelCaseObjectMapper.writeValueAsString(Map("firstName" -> "Bob"))
   }
 
-  post("/createUser") {user: CreateUserRequest =>
+  post("/createUser") { user: CreateUserRequest =>
     response.created.location(s"/users/${user.requestId}")
   }
 

--- a/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/main/domain/CreateUserRequest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/main/domain/CreateUserRequest.scala
@@ -1,0 +1,9 @@
+package com.twitter.finatra.http.integration.doeverything.main.domain
+
+import com.twitter.finatra.request.Header
+
+case class CreateUserRequest(
+  @Header requestId: String,
+  name: String,
+  age: Int)
+

--- a/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -1161,7 +1161,7 @@ class DoEverythingServerFeatureTest extends FeatureTest {
       withJsonBody = """
       {
         "errors": [
-          "max: field is required",
+          "max: queryParam is required",
           "verbose: '5' is not a valid boolean"
         ]
       }
@@ -1234,7 +1234,7 @@ class DoEverythingServerFeatureTest extends FeatureTest {
       andExpect = BadRequest,
       withJsonBody = """{
         "errors" : [
-          "param: field is required"
+          "param: queryParam is required"
         ]
       }""")
   }
@@ -1393,6 +1393,14 @@ class DoEverythingServerFeatureTest extends FeatureTest {
       andExpect = BadRequest,
       withBody = """{"errors":["request_id: header is required"]}"""
     )
+  }
+
+  "Bad request for missing form param" in {
+    server.httpFormPost(
+      "/formPost",
+      params = Map("name" -> "bob"),
+      andExpect = BadRequest,
+      withBody = """{"errors":["age: formParam is required"]}""")
   }
 
   "accepts request with header and body" in {

--- a/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -1385,4 +1385,23 @@ class DoEverythingServerFeatureTest extends FeatureTest {
     // not a thrift server so, port should be None
     server.twitterServer.thriftPort shouldBe None
   }
+
+  "Bad request for missing header" in {
+    server.httpPost(
+      "/createUser",
+      postBody = """{"name":"bob", "age":50}""",
+      andExpect = BadRequest,
+      withBody = """{"errors":["request_id: header is required"]}"""
+    )
+  }
+
+  "accepts request with header and body" in {
+    server.httpPost(
+      "/createUser",
+      headers = Map("request_id" -> "732647326473"),
+      postBody = """{"name":"bob", "age":50}""",
+      andExpect = Created,
+      withLocation = "/users/732647326473"
+    )
+  }
 }

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassField.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassField.scala
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.node.TreeTraversingParser
 import com.fasterxml.jackson.databind.util.ClassUtil
+import com.twitter.finatra.json.internal.caseclass.annotations.HeaderInternal
 import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassValidationException
 import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassValidationException.PropertyPath
 import com.twitter.finatra.json.internal.caseclass.reflection.CaseClassSigParser
@@ -81,9 +82,13 @@ case class CaseClassField(
 
   private val isOption = javaType.getRawClass == classOf[Option[_]]
   private val isString = javaType.getRawClass == classOf[String]
+  private val attributeType = findAnnotation[HeaderInternal](annotations) match {
+    case Some(header) => "header"
+    case _ => "field"
+  }
   private val fieldInjection = new FieldInjection(name, javaType, parentClass, annotations)
   private lazy val firstTypeParam = javaType.containedType(0)
-  private lazy val requiredFieldException = CaseClassValidationException(PropertyPath.leaf(name), Invalid("field is required", ErrorCode.RequiredFieldMissing))
+  private lazy val requiredFieldException = CaseClassValidationException(PropertyPath.leaf(name), Invalid(s"$attributeType is required", ErrorCode.RequiredFieldMissing))
 
   /* Public */
 


### PR DESCRIPTION
An attempt to fix  https://github.com/twitter/finatra/issues/263

Problem

Case class validation error message says field is required when header is missing

Solution

Improved case class validation error message based on @Header annotation

Result

Validation error message now says header is required