### PR TITLE
finatra: fix wrong content-length of UTF-8 string in httpclient

### DIFF
--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/RequestBuilder.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/RequestBuilder.scala
@@ -3,6 +3,7 @@ package com.twitter.finatra.httpclient
 import com.google.common.net.HttpHeaders
 import com.twitter.finagle.http.{Message, Method, Request, RequestProxy}
 import org.apache.commons.io.IOUtils
+import com.twitter.io.Charsets
 
 /**
  * Provides a class for building <code>finagle.http.Request</code> objects
@@ -74,7 +75,7 @@ class RequestBuilder(
 
   def body(string: String, contentType: String = Message.ContentTypeJson): RequestBuilder = {
     request.setContentString(string)
-    request.headerMap.add(HttpHeaders.CONTENT_LENGTH, string.length.toString)
+    request.headerMap.add(HttpHeaders.CONTENT_LENGTH, string.getBytes(Charsets.Utf8).length.toString)
     request.headerMap.add(HttpHeaders.CONTENT_TYPE, contentType)
     this
   }

--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/RequestBuilder.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/RequestBuilder.scala
@@ -2,8 +2,8 @@ package com.twitter.finatra.httpclient
 
 import com.google.common.net.HttpHeaders
 import com.twitter.finagle.http.{Message, Method, Request, RequestProxy}
-import org.apache.commons.io.IOUtils
 import com.twitter.io.Charsets
+import org.apache.commons.io.IOUtils
 
 /**
  * Provides a class for building <code>finagle.http.Request</code> objects

--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/RequestBuilderTest.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/RequestBuilderTest.scala
@@ -24,7 +24,7 @@ class RequestBuilderTest extends Test {
 
   "post" in {
     val request = RequestBuilder.post("/abc")
-      .body("testbody", "foo/bar")
+      .body("testbody．", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -35,7 +35,7 @@ class RequestBuilderTest extends Test {
 
   "put" in {
     val request = RequestBuilder.put("/abc")
-      .body("testbody", "foo/bar")
+      .body("testbody．", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -46,7 +46,7 @@ class RequestBuilderTest extends Test {
 
   "patch" in {
     val request = RequestBuilder.patch("/abc")
-      .body("testbody", "foo/bar")
+      .body("testbody．", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -57,7 +57,7 @@ class RequestBuilderTest extends Test {
 
   "delete" in {
     val request = RequestBuilder.delete("/abc")
-      .body("testbody", "foo/bar")
+      .body("testbody．", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -68,7 +68,7 @@ class RequestBuilderTest extends Test {
 
   "head" in {
     val request = RequestBuilder.head("/abc")
-      .body("testbody", "foo/bar")
+      .body("testbody．", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -93,9 +93,9 @@ class RequestBuilderTest extends Test {
       "a" -> "1",
       "b" -> "2",
       "c" -> "3",
-      "Content-Length" -> "8",
+      "Content-Length" -> "11",
       "Content-Type" -> "foo/bar"))
 
-    request.contentString should be("testbody")
+    request.contentString should be("testbody．")
   }
 }

--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/RequestBuilderTest.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/RequestBuilderTest.scala
@@ -24,7 +24,7 @@ class RequestBuilderTest extends Test {
 
   "post" in {
     val request = RequestBuilder.post("/abc")
-      .body("testbody．", "foo/bar")
+      .body("testbody", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -35,7 +35,7 @@ class RequestBuilderTest extends Test {
 
   "put" in {
     val request = RequestBuilder.put("/abc")
-      .body("testbody．", "foo/bar")
+      .body("testbody", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -46,7 +46,7 @@ class RequestBuilderTest extends Test {
 
   "patch" in {
     val request = RequestBuilder.patch("/abc")
-      .body("testbody．", "foo/bar")
+      .body("testbody", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -57,7 +57,7 @@ class RequestBuilderTest extends Test {
 
   "delete" in {
     val request = RequestBuilder.delete("/abc")
-      .body("testbody．", "foo/bar")
+      .body("testbody", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -68,7 +68,7 @@ class RequestBuilderTest extends Test {
 
   "head" in {
     val request = RequestBuilder.head("/abc")
-      .body("testbody．", "foo/bar")
+      .body("testbody", "foo/bar")
       .headers(Seq("c" -> "3"))
       .headers(
         "a" -> "1",
@@ -85,6 +85,13 @@ class RequestBuilderTest extends Test {
     request.contentString should be("{}")
   }
 
+  "post utf8 content" in {
+    val request = RequestBuilder.post("/abc")
+      .body("ＴＥＳＴＢＯＤＹ")
+
+    request.headerMap("Content-Length") should be("24")
+  }
+
   def assertRequestWithBody(expectedMethod: Method, request: RequestBuilder): Unit = {
     request.uri should be("/abc")
     request.method should be(expectedMethod)
@@ -93,9 +100,9 @@ class RequestBuilderTest extends Test {
       "a" -> "1",
       "b" -> "2",
       "c" -> "3",
-      "Content-Length" -> "11",
+      "Content-Length" -> "8",
       "Content-Type" -> "foo/bar"))
 
-    request.contentString should be("testbody．")
+    request.contentString should be("testbody")
   }
 }


### PR DESCRIPTION
fix wrong content-length of UTF-8 string in httpclient