### PR TITLE
Remove admin port on Heroku Procfile in example

### DIFF
--- a/examples/hello-world-heroku/Procfile
+++ b/examples/hello-world-heroku/Procfile
@@ -1,1 +1,1 @@
-web: target/universal/stage/bin/hello-world-heroku -- -admin.port=:$PORT -http.port=:$PORT
+web: target/universal/stage/bin/hello-world-heroku -- -http.port=:$PORT


### PR DESCRIPTION
You can't bind to a port multiple times. This example is broken.