### PR TITLE
Pass disableTestLogging argument to EmbeddedApp & EmbeddedTwitterServer

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/test/EmbeddedHttpServer.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/test/EmbeddedHttpServer.scala
@@ -36,6 +36,7 @@ class EmbeddedHttpServer(
     defaultRequestHeaders = defaultRequestHeaders,
     streamResponse = streamResponse,
     verbose = verbose,
+    disableTestLogging = disableTestLogging,
     maxStartupTimeSeconds = maxStartupTimeSeconds) {
 
   /* Overrides */

--- a/inject/inject-server/src/test/scala/com/twitter/inject/server/EmbeddedTwitterServer.scala
+++ b/inject/inject-server/src/test/scala/com/twitter/inject/server/EmbeddedTwitterServer.scala
@@ -80,6 +80,7 @@ class EmbeddedTwitterServer(
     skipAppMain = skipAppMain,
     stage = stage,
     verbose = verbose,
+    disableTestLogging = disableTestLogging,
     maxStartupTimeSeconds = maxStartupTimeSeconds) {
 
   /* Additional Constructors */

--- a/thrift/src/test/scala/com/twitter/finatra/thrift/EmbeddedThriftServer.scala
+++ b/thrift/src/test/scala/com/twitter/finatra/thrift/EmbeddedThriftServer.scala
@@ -44,6 +44,7 @@ class EmbeddedThriftServer(
     useSocksProxy,
     skipAppMain,
     verbose = verbose,
+    disableTestLogging = disableTestLogging,
     maxStartupTimeSeconds = maxStartupTimeSeconds)
   with ThriftClient {
 


### PR DESCRIPTION
Problem
The disableTestLogging constructor parameter in EmbeddedHttpServer,
EmbeddedThriftServer and EmbeddedTwitterServer is not passed to the EmbeddedApp
constructor. This means the parameter does not have any effect and all tests
produce a full verbose output even when this is not desired.

Resolution
Pass the disableTestLogging argument to the parent constructors.