### PR TITLE
Path parameter values are properly urldecoded

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/internal/routing/PathPattern.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/routing/PathPattern.scala
@@ -2,6 +2,7 @@ package com.twitter.finatra.http.internal.routing
 
 import com.twitter.inject.Logging
 import java.util.regex.Matcher
+import org.jboss.netty.handler.codec.http.QueryStringDecoder
 import scala.collection.immutable
 import scala.util.matching.Regex
 
@@ -58,7 +59,7 @@ case class PathPattern(
 
     for (captureName <- captureNames) {
       idx += 1
-      builder += captureName -> matcher.group(idx)
+      builder += captureName -> QueryStringDecoder.decodeComponent(matcher.group(idx))
     }
     builder.result()
   }

--- a/http/src/test/scala/com/twitter/finatra/http/routing/PathPatternTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/routing/PathPatternTest.scala
@@ -37,6 +37,11 @@ class PathPatternTest extends Test {
       PathPattern("/cars/:make/:model/:*").extract("/cars/ford/explorer/foo/bar") should equal(Some(Map("make" -> "ford", "model" -> "explorer", "*" -> "foo/bar")))
     }
 
+    "decode route params" in {
+      PathPattern("/:foo").extract("/hello%3Aworld") should equal(Some(Map("foo" -> "hello:world")))
+      PathPattern("/:foo").extract("/hello:world") should equal(Some(Map("foo" -> "hello:world")))
+    }
+
     "non capture group syntax" in {
       PathPattern("/(?:cars|boats)/:id").extract("/cars/123") should equal(None)
       PathPattern("/(?:cars|boats)/:id").extract("/boats/123") should equal(None)


### PR DESCRIPTION
Seems like it was previously fixed in 1.5.1, but not "backported" in 2.X.