### PR TITLE
Fix order of validation error messages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ class TwitterCloneFeatureTest extends FeatureTest with Mockito {
       withJsonBody = """
         {
           "errors" : [
-            "message: size [0] is not between 1 and 140",
             "location.lat: [9999.0] is not between -85 and 85",
             "location.long: field is required",
+            "message: size [0] is not between 1 and 140",
             "nsfw: 'abc' is not a valid boolean"
           ]
         }


### PR DESCRIPTION
According to 540bced600260bb2e5034b3ba7ebf8d2a5e4dacc, validation error messages are now sorted  in lexicographic order.