### PR TITLE
Fix AutoClosable.scala

### DIFF
--- a/utils/src/main/scala/com/twitter/finatra/utils/AutoClosable.scala
+++ b/utils/src/main/scala/com/twitter/finatra/utils/AutoClosable.scala
@@ -1,12 +1,10 @@
 package com.twitter.finatra.utils
 
+import scala.util.control.Exception._
+
 object AutoClosable {
 
   def tryWith[AC <: AutoCloseable, T](ac: AC)(func: AC => T): T = {
-    try {
-      func(ac)
-    } finally {
-      ac.close()
-    }
+    allCatch andFinally ac.close() apply func(ac)
   }
 }


### PR DESCRIPTION
minor changes.

`try catch finally` looks bad, so I refactor it to `allCatch andFinally apply`. 

It is because `allCatch andFinally apply`  looks neat.

test passed locally.