### PR TITLE
finatra-httpclient: Pass expected POST body to InMemoryHttpService map

### DIFF
--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/InMemoryHttpServiceTest.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/InMemoryHttpServiceTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.httpclient
 
 import com.twitter.finagle.http.{Method, Request, Response}
-import com.twitter.finatra.httpclient.test.InMemoryHttpService
+import com.twitter.finatra.httpclient.test.{InMemoryHttpService, PostRequestWithIncorrectBodyException}
 import com.twitter.inject.Test
 import com.twitter.util.Await
 import org.specs2.mock.Mockito
@@ -34,7 +34,7 @@ class InMemoryHttpServiceTest extends Test with Mockito {
 
     val request = Request(Method.Post, "/foo")
     request.setContentString("11111")
-    assertFailedFuture[Exception] {
+    assertFailedFuture[PostRequestWithIncorrectBodyException] {
       inMemoryHttpService.apply(request)
     }
   }

--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/test/InMemoryHttpService.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/test/InMemoryHttpService.scala
@@ -43,16 +43,16 @@ class InMemoryHttpService
   }
 
   def mockPost(path: String, withBody: String = null, andReturn: Response, sticky: Boolean = false) {
-    mock(Post, path, andReturn, sticky)
+    mock(Post, path, andReturn, sticky, Option(withBody))
   }
 
   def mockPut(path: String, withBody: String = null, andReturn: Response, sticky: Boolean = false) {
     mock(Put, path, andReturn, sticky)
   }
 
-  def mock(method: Method, path: String, andReturn: Response, sticky: Boolean): Unit = {
+  def mock(method: Method, path: String, andReturn: Response, sticky: Boolean, withBody: Option[String] = None): Unit = {
     val existing = responseMap(RequestKey(method, path))
-    val newEntry = ResponseWithExpectedBody(andReturn, None, sticky = sticky)
+    val newEntry = ResponseWithExpectedBody(andReturn, withBody, sticky = sticky)
     responseMap(
       RequestKey(method, path)) = existing :+ newEntry
   }
@@ -93,7 +93,7 @@ class InMemoryHttpService
 
   private def lookupPostResponseWithBody(request: Request, existing: ArrayBuffer[ResponseWithExpectedBody]): Response = {
     val found = existing find {_.expectedBody == Some(request.contentString)} getOrElse {
-      throw new Exception(request + " with expected body not mocked")
+      throw new PostRequestWithIncorrectBodyException(request + " with expected body not mocked")
     }
 
     if (!found.sticky) {

--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/test/PostRequestWithIncorrectBodyException.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/test/PostRequestWithIncorrectBodyException.scala
@@ -1,0 +1,3 @@
+package com.twitter.finatra.httpclient.test
+
+private[httpclient] class PostRequestWithIncorrectBodyException(message: String) extends RuntimeException(message)


### PR DESCRIPTION
Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Describe the modifications you've done.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.

Problem

The InMemoryHttpService allows tests to specify an expected body when mocking a
POST request.  This body is not being passed through to the map of responses, so
tests which should fail are passing.  Additionally, the test for this
functionality is faulty, because a generic "Exception" is expected to be thrown
when a non-expected body is received.  The assertFailedFuture test helper method
does not work for generic Exceptions, because the ScalaTest fail() method throws
an exception which is also caught.

Solution

Pass the "withBody" parameter from "mockPost" through to the responseMap.
Introduce PostRequestWithIncorrectBodyException so that the  "post mocked with
different body" test reports correctly.