### PR TITLE
examples: Fixes Incorrect Example Documentation Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ All notable changes to this project will be documented in this file. Note that `
 
 ### Closed
 
-## [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6) (2016-04-26)
+## [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6) (2016-04-26)
+
+[Full Changelog](https://github.com/twitter/finatra/compare/v2.1.5...finatra-2.1.6)
 
 ### Added
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ For more detailed information see the README.md within each example project.
 A test server that provides benchmarking for key Finatra features.
 
 ### [hello-world](hello-world/README.md)
-An example [Finatra][finatra] application that highlights features of the [finatra-http](https://github.com/twitter/finatra/tree/master/http) framework.
+An example [Finatra][finatra] application that highlights features of the [finatra-http](https://github.com/twitter/finatra/tree/develop/http) framework.
 
 ### [java-server](java-server/README.md)
 An example [Finatra][finatra] application written in Java.
@@ -20,7 +20,7 @@ An example [Finatra][finatra] application written in Java.
 An advanced example that creates a Twitter Clone application demonstrating many [Finatra][finatra] features.
 
 ### [hello-world-heroku](hello-world-heroku/README.md)
-An example [Finatra][finatra] application that highlights features of the [finatra-http](https://github.com/twitter/finatra/tree/master/http) framework that is deployable to [Heroku](https://heroku.com).
+An example [Finatra][finatra] application that highlights features of the [finatra-http](https://github.com/twitter/finatra/tree/develop/http) framework that is deployable to [Heroku](https://heroku.com).
 
 ### [streaming-example](streaming-example/README.md)
 A proof-of-concept streaming JSON service.

--- a/examples/benchmark-server/README.md
+++ b/examples/benchmark-server/README.md
@@ -10,14 +10,14 @@ $ cd ../../
 $ sbt benchmarkServer/run
 ```
 * Then browse to: [http://localhost:8888/json](http://localhost:8888/json)
-* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#http-admin-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
+* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 * Or build and run a deployable jar:
 ```
 $ sbt benchmarkServer/assembly
 $ java -jar examples/benchmark-server/target/scala-2.11/finatra-benchmark-server-assembly-2.x.x-SNAPSHOT.jar -http.port=:8888 -admin.port=:9990
 ```
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 Run sbt from **this** project's directory, e.g.
 ```

--- a/examples/hello-world-heroku/README.md
+++ b/examples/hello-world-heroku/README.md
@@ -7,7 +7,7 @@ If you're in master or a feature branch
 ----------------------------------------------------------
 * Development from master or feature branches is not currently supported for this example. Please switch to a release branch and see the instructions below.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 
 ### Run the server on Heroku ###

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -11,7 +11,7 @@ $ cd ../../
 $ sbt helloWorld/run
 ```
 * Then browse to: [http://localhost:8888/hi?name=foo](http://localhost:8888/hi?name=foo)
-* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#http-admin-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
+* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 * Or build and run a deployable jar:
 ```
 $ sbt helloWorld/assembly
@@ -19,7 +19,7 @@ $ java -jar -Dlog.service.output=hello-world.log -Dlog.access.output=access.log 
 ```
 *Note*: adding the java args `-Dlog.service.output` and `-Dlog.access.output` is optional and they can be set to any location on disk or to `/dev/stdout` or `/dev/stderr` for capturing log output. When not set the [logback.xml](./src/main/resources/logback.xml) is parameterized with defaults of `service.log` and `access.log`, respectively.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 ###SBT###
 Run sbt from **this** project's directory, e.g.

--- a/examples/java-http-server/README.md
+++ b/examples/java-http-server/README.md
@@ -2,13 +2,13 @@
 
 ### NOTE: this example *only* works with Java 8
 
-If you are trying to use this as an example of how to write an http server with Finatra, please note that the syntax **only** functions properly in JDK 8. Please see the [java-server](examples/java-server) for how to develop a java server for java versions < JDK 8.
+If you are trying to use this as an example of how to write an http server with Finatra, please note that the syntax **only** functions properly in JDK 8. Please see the [java-server](../java-server) for how to develop a java server for java versions < JDK 8.
 
 This example is also not available in the root build, thus it's only
 
 * A simple "hello world" example for JDK 8.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 ###SBT###
 Run sbt from **this** project's directory, e.g.

--- a/examples/java-server/README.md
+++ b/examples/java-server/README.md
@@ -17,7 +17,7 @@ $ java -jar -Dlog.service.output=java-server.log inject/examples/java-server/tar
 ```
 *Note*: adding the java args `-Dlog.service.output` and `-Dlog.access.output` is optional and they can be set to any location on disk or to `/dev/stdout` or `/dev/stderr` for capturing log output. When not set the [logback.xml](./src/main/resources/logback.xml) is parameterized with defaults of `service.log` and `access.log`, respectively.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 ###SBT###
 Run sbt from **this** project's directory, e.g.

--- a/examples/streaming-example/README.md
+++ b/examples/streaming-example/README.md
@@ -9,20 +9,20 @@ Run sbt from the top-level Finatra directory, e.g.
 $ cd ../../
 $ sbt streamingExample/run
 ```
-* Then browse the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#http-admin-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
+* Then browse the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 * Or build and run a deployable jar:
 ```
 $ sbt streamingExample/assembly
 $ java -jar examples/streaming-example/target/scala-2.11/finatra-benchmark-server-assembly-2.x.x-SNAPSHOT.jar -http.port=:8888 -admin.port=:9990
 ```
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 Run sbt from **this** project's directory, e.g.
 ```
 $ sbt run
 ```
-* Then browse to the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#http-admin-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
+* Then browse to the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 Or build and run a deployable jar:
 ```
 $ sbt assembly

--- a/examples/thrift-server/README.md
+++ b/examples/thrift-server/README.md
@@ -16,9 +16,9 @@ $ sbt thriftExampleServer/run
 $ sbt thriftExampleServer/assembly
 $ java -jar -Dlog.service.output=thrift-server.log -Dlog.access.output=access.log examples/thrift-server/thrift-example-server/target/scala-2.11/thrift-example-server-assembly-2.x.x-SNAPSHOT.jar -thrift.port=:9999 -admin.port=:9990
 ```
-*Note*: adding the java args `-Dlog.service.output` and `-Dlog.access.output` is optional and they can be set to any location on disk or to `/dev/stdout` or `/dev/stderr` for capturing log output. When not set the [logback.xml](./src/main/resources/logback.xml) is parameterized with defaults of `service.log` and `access.log`, respectively.
+*Note*: adding the java args `-Dlog.service.output` and `-Dlog.access.output` is optional and they can be set to any location on disk or to `/dev/stdout` or `/dev/stderr` for capturing log output. When not set the [logback.xml](./thrift-example-server/src/main/resources/logback.xml) is parameterized with defaults of `service.log` and `access.log`, respectively.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 ###SBT###
 Run sbt from **this** project's directory, e.g.

--- a/examples/tiny-url/README.md
+++ b/examples/tiny-url/README.md
@@ -6,7 +6,7 @@ If you're in master or a feature branch
 ----------------------------------------------------------
 * Development from master or feature branches is not currently supported for this example. Please switch to a release branch and see the instructions below.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 
 ### Building

--- a/examples/twitter-clone/README.md
+++ b/examples/twitter-clone/README.md
@@ -10,7 +10,7 @@ $ cd ../../
 $ sbt "project twitterClone" "run -firebase.host=finatra.firebaseio.com -com.twitter.server.resolverMap=firebase=finatra.firebaseio.com:443"
 ```
 * Then browse to: [http://127.0.0.1:8888/tweet/04fa10f9-8188-4bd2-b4e0-46fd09b77aa9](http://127.0.0.1:8888/tweet/04fa10f9-8188-4bd2-b4e0-46fd09b77aa9)
-* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#http-admin-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
+* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 * Or build and run a deployable jar:
 ```
 $ sbt twitterClone/assembly
@@ -18,14 +18,14 @@ $ java -jar -Dlog.service.output=twitter-clone.log -Dlog.access.output=access.lo
 ```
 *Note*: adding the java args `-Dlog.service.output` and `-Dlog.access.output` is optional and they can be set to any location on disk or to `/dev/stdout` or `/dev/stderr` for capturing log output. When not set the [logback.xml](./src/main/resources/logback.xml) is parameterized with defaults of `service.log` and `access.log`, respectively.
 
-If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/v2.1.6))
+If you're in a tagged release branch (e.g. [v2.1.6](https://github.com/twitter/finatra/tree/finatra-2.1.6))
 ----------------------------------------------------------
 Run sbt from **this** project's directory, e.g.
 ```
 $ sbt "run -firebase.host=finatra.firebaseio.com -com.twitter.server.resolverMap=firebase=finatra.firebaseio.com:443"
 ```
 * Then browse to: [http://127.0.0.1:8888/tweet/04fa10f9-8188-4bd2-b4e0-46fd09b77aa9](http://127.0.0.1:8888/tweet/04fa10f9-8188-4bd2-b4e0-46fd09b77aa9)
-* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#http-admin-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
+* Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 Or build and run a deployable jar:
 ```
 $ sbt assembly


### PR DESCRIPTION
Problem

There are several places in the examples have links that point
to incorrect locations resulting in 404 errors in some cases.

Solution

This pull request adds the correct links to those places in the documentation
as well as includes the "Full Changelog"
link that was missing in the `CHANGELOG.md` document.

Result

Working links in documentation