### PR TITLE
finatra-examples: Add sbt-revolver to the hello-world example

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -26,6 +26,10 @@ Run sbt from **this** project's directory, e.g.
 ```
 $ sbt run
 ```
+Or with [sbt-revolver](https://github.com/spray/sbt-revolver):
+```
+$ sbt "~re-start"
+```
 Or build and run a deployable jar:
 ```
 $ sbt assembly

--- a/examples/hello-world/build.sbt.for_release_branches_only
+++ b/examples/hello-world/build.sbt.for_release_branches_only
@@ -20,6 +20,8 @@ assemblyMergeStrategy in assembly := {
   case other => MergeStrategy.defaultMergeStrategy(other)
 }
 
+Revolver.settings
+
 libraryDependencies ++= Seq(
   "com.twitter" %% "finatra-http" % versions.finatra,
   "com.twitter" %% "finatra-httpclient" % versions.finatra,

--- a/examples/hello-world/project/resolver.sbt
+++ b/examples/hello-world/project/resolver.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")


### PR DESCRIPTION
Fixes #209 
Closes #273 
Closes #324 

Problem

The documentation does not mention anything about reloading the server when
changes are made. There have also been issues created requesting this feature.

Solution

sbt-revolver is a plugin that provides the ability to reload(compile and run)
the server when source files are changed.

Result

The hello-world example can now be run with `sbt "~re-start"` to enable the
feature.