### PR TITLE
Generic MessageBodyReader

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/MessageBodyManager.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/MessageBodyManager.scala
@@ -41,6 +41,11 @@ class MessageBodyManager @Inject()(
       singleTypeParam(componentSupertypeType))
   }
 
+  def add[MBC <: MessageBodyComponent : Manifest](reader: MBC) = {
+    val componentSupertypeType = typeLiteral[MBC].getSupertype(classOf[MessageBodyReader[_]]).getType
+    addComponent(reader, singleTypeParam(componentSupertypeType))
+  }
+
   def addByAnnotation[Ann <: Annotation : Manifest, T <: MessageBodyWriter[_] : Manifest](): Unit = {
     val messageBodyWriter = injector.instance[T]
     val annot = manifest[Ann].runtimeClass.asInstanceOf[Class[Ann]]
@@ -64,13 +69,20 @@ class MessageBodyManager @Inject()(
     val requestManifest = manifest[T]
     readerCache.getOrElseUpdate(requestManifest, {
       val objType = typeLiteral(requestManifest).getType
-      classTypeToReader.get(objType)
+      classTypeToReader.get(objType) orElse findReaderBySuperType(objType)
     }) match {
       case Some(reader) =>
         reader.parse(request).asInstanceOf[T]
       case _ =>
         defaultMessageBodyReader.parse[T](request)
     }
+  }
+
+  private def findReaderBySuperType(t: Type): Option[MessageBodyReader[Any]] = {
+    classTypeToReader.toList
+      .filter(_._1.asInstanceOf[Class[_]].isAssignableFrom(t.asInstanceOf[Class[_]]))
+      .map(_._2)
+      .headOption
   }
 
   // Note: writerCache is bounded on the number of unique classes returned from controller routes */
@@ -85,7 +97,10 @@ class MessageBodyManager @Inject()(
 
   private def add[MessageBodyComp: Manifest](typeToReadOrWrite: Type): Unit = {
     val messageBodyComponent = injector.instance[MessageBodyComp]
+    addComponent(messageBodyComponent, typeToReadOrWrite)
+  }
 
+  private def addComponent(messageBodyComponent: Any, typeToReadOrWrite: Type): Unit = {
     messageBodyComponent match {
       case reader: MessageBodyReader[_] =>
         classTypeToReader(typeToReadOrWrite) = reader.asInstanceOf[MessageBodyReader[Any]]

--- a/http/src/main/scala/com/twitter/finatra/http/marshalling/MessageBodyReader.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/marshalling/MessageBodyReader.scala
@@ -3,5 +3,5 @@ package com.twitter.finatra.http.marshalling
 import com.twitter.finagle.http.Request
 
 trait MessageBodyReader[T] extends MessageBodyComponent {
-  def parse(request: Request): T
+  def parse[M <: T : Manifest](request: Request): T
 }

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/domain/DomainTestUserReader.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/domain/DomainTestUserReader.scala
@@ -10,7 +10,7 @@ class DomainTestUserReader @Inject()(
   mapper: FinatraObjectMapper)
   extends MessageBodyReader[DomainTestUser] {
 
-  override def parse(request: Request): DomainTestUser = {
+  override def parse[M: Manifest](request: Request): DomainTestUser = {
     val jsonNode = mapper.parse[JsonNode](request)
     val testUser = mapper.parse[TestUser](jsonNode)
     DomainTestUser(testUser.name)

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/tweetexample/main/domain/TweetMessageBodyReader.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/tweetexample/main/domain/TweetMessageBodyReader.scala
@@ -9,7 +9,7 @@ class TweetMessageBodyReader @Inject()(
   mapper: FinatraObjectMapper)
   extends MessageBodyReader[Tweet] {
 
-  override def parse(request: Request): Tweet = {
+  override def parse[M: Manifest](request: Request): Tweet = {
     val tweetRequest = mapper.parse[TweetRequest](request)
     Tweet(
       tweetRequest.customId,


### PR DESCRIPTION
Problem

MessageBodyReader doesn't support runtime class discovery which makes
impossible to create generic body readers

Solution

Change parse method signature in order to receive the Manifest which
allow runtime class identification

Result

parse method can discovery the runtime class which makes possible to
create generic body readers. Now we can also add MessageBodyReaders by
instance instead of just by type

@cacoco 