### PR TITLE
[AsyncStream] it consumes 34 secs for only one 104 KB string request

### DIFF
--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/ByteBufferUtils.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/ByteBufferUtils.scala
@@ -20,11 +20,13 @@ private[finatra] object ByteBufferUtils extends Logging {
   }
 
   def debugBuffer(byteBuffer: ByteBuffer) = {
-    val copy = byteBuffer.duplicate()
-    copy.position(0)
-    val buf = Buf.ByteBuffer.Shared(copy)
-    val str = buf.utf8str
+    if (logger.isDebugEnabled) { 
+      val copy = byteBuffer.duplicate()
+      copy.position(0)
+      val buf = Buf.ByteBuffer.Shared(copy)
+      val str = buf.utf8str
 
-    debug(s"byteBuffer: $str pos: ${byteBuffer.position }")
+      debug(s"byteBuffer: $str pos: ${byteBuffer.position }")
+    }
   }
 }


### PR DESCRIPTION
Problem

The endpoint with request type AsyncStream is time-consuming. From test, it
totally consumes 34 seconds in 38 seconds for only one string request with 104KB
(Note, 38 seconds is duration of http request completion). The root cause is
that the method buf.utf8str is time-consuming and called by
ByteBufferUtils.debugBuffer.

Solution

Since ByteBufferUtils.debugBuffer is for debugging purpose, we can limit it to
run only in debugging mode by logger.isDebugEnabled

Result

After applying solution, the time consumption is reduced to 0.254 seconds. It
improves a lot.