### PR TITLE
Update ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,3 +6,4 @@ Twitter isn't the only company using Finatra. We're sure the following list isn'
 [1]: https://github.com/twitter/finatra/blob/master/CONTRIBUTING.md
 
 * [Grovo](https://www.grovo.com/)
+* [Kueski](https://kueski.com)


### PR DESCRIPTION
Problem

Kueski company is adopting Finatra for some of its projects.

Solution

Add Kueski company as a Finatra adopter.

Result

A link to Kueski company website is in ADOPTERS.md

