### PR TITLE
finatra-http ResponseBuilder.fileOrIndex verify when file exists

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/response/ResponseBuilder.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/response/ResponseBuilder.scala
@@ -356,12 +356,12 @@ class ResponseBuilder @Inject()(
     }
 
     /**
-     * Return the file (only if it's a file w/ an extension), otherwise return the index.
+     * Return the file (only if it's an existing file w/ an extension), otherwise return the index.
      * Note: This functionality is useful for "single-page" UI frameworks (e.g. AngularJS)
      * that perform client side routing.
      */
     def fileOrIndex(filePath: String, indexPath: String) = {
-      if (isFile(filePath))
+      if (isFile(filePath) && hasFile(filePath))
         file(filePath)
       else
         file(indexPath)
@@ -477,6 +477,14 @@ class ResponseBuilder @Inject()(
 
     private def isFile(requestPath: String) = {
       getExtension(requestPath).nonEmpty
+    }
+
+    private def hasFile(file: String): Boolean = {
+      val fileWithSlash = if (file.startsWith("/")) file else "/" + file
+      fileResolver.getInputStream(fileWithSlash).map { is =>
+        is.close
+        true
+      }.getOrElse(false)
     }
 
     private def mediaToString(mediaType: MediaType): String = {

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/fileserver/LocalFileServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/fileserver/LocalFileServerFeatureTest.scala
@@ -5,7 +5,9 @@ import com.twitter.finatra.http.filters.CommonFilters
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.http.EmbeddedHttpServer
 import com.twitter.finatra.http.{Controller, HttpServer}
+import com.twitter.finatra.test.LocalFilesystemTestUtils
 import com.twitter.inject.Test
+import org.apache.commons.io.FileUtils
 
 class LocalFileServerFeatureTest extends Test {
 
@@ -36,6 +38,49 @@ class LocalFileServerFeatureTest extends Test {
       server.httpGet(
         "/foo",
         andExpect = Status.NotFound)
+    }
+  }
+
+  "server existing file" in {
+    val path = "/tmp"
+    val filename = "finatra-test-file.txt"
+    val fileContent = "file content"
+    val file = LocalFilesystemTestUtils.createFile(s"$path/$filename")
+    FileUtils.writeStringToFile(file, fileContent)
+    assertServer(
+      new Controller {
+        get("/foo") { request: Request =>
+          response.ok.fileOrIndex(filename, "index.html")
+        }
+      },
+      flags = Map(
+        "local.doc.root" -> path)) { server =>
+      server.httpGet(
+        "/foo",
+        andExpect = Status.Ok,
+        withBody = fileContent)
+    }
+  }
+
+  "server index when file doesn't exists" in {
+    val path = "/tmp"
+    val indexName = "index.html"
+    val filename = "non-existing-file.txt"
+    val indexContent = "index content"
+    val index = LocalFilesystemTestUtils.createFile(s"$path/$indexName")
+    FileUtils.writeStringToFile(index, indexContent)
+    assertServer(
+      new Controller {
+        get("/foo") { request: Request =>
+          response.ok.fileOrIndex(filename, indexName)
+        }
+      },
+      flags = Map(
+        "local.doc.root" -> path)) { server =>
+      server.httpGet(
+        "/foo",
+        andExpect = Status.Ok,
+        withBody = indexContent)
     }
   }
 


### PR DESCRIPTION
Problem

ResponseBuilder.fileOrIndex method is not verifying when the file exists in
the file system but validating that it contains a file extension. This leads
to get http error 404 (Not found) when the file has an extension and doesn't
exists (see issue #360).

Solution

Lets implement a method hasFile at ResponseBuilder which checks when the
file exists and can be retrieved by fileResolver.getInputStream method.

Modify method fileOrIndex from ResponseBuilder to check when the file exists
to avoid http error 404.

Result

Calling method fileOrIndex from ResponseBuilder won't return http error 404
when file doesn't exists but return index.