### PR TITLE
added jackson-datatype-jsr310 dependency and module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -475,6 +475,7 @@ lazy val jackson = project
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-databind" % versions.jackson,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % versions.jackson,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % versions.jackson,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % versions.jackson,
       "org.scala-lang" % "scalap" % scalaVersion.value exclude("org.scala-lang", "scala-compiler"),
       "com.twitter.finatra" %% "finatra-scalap-compiler-deps" % "2.0.0"

--- a/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala
@@ -84,6 +84,7 @@ class FinatraJacksonModule extends TwitterModule {
   /** Jackson Modules to load */
   protected def defaultJacksonModules: Seq[JacksonModule] = Seq(
     new JodaModule,
+    new JavaTimeModule,
     DefaultScalaModule,
     LongKeyDeserializers,
     FinatraSerDeSimpleModule) //FinatraModule's need to be added 'last' so they can override existing deser's

--- a/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala
@@ -16,6 +16,9 @@ import com.twitter.finatra.json.internal.serde.{FinatraSerDeSimpleModule, LongKe
 import com.twitter.finatra.json.utils.CamelCasePropertyNamingStrategy
 import com.twitter.inject.TwitterModule
 import javax.inject.Singleton
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+
 import scala.collection.JavaConverters._
 
 


### PR DESCRIPTION
Problem

Deserializing a case class with a JSR310 datatype such as `LocalDateTime` results in a jackson exception like the following

Example case class:

``` scala
case class ResponseCaseClass(id: UUID, name: String, createdAt: LocalDateTime, updatedAt: LocalDateTime, deletedAt: Option[LocalDateTime])
```

exception:

```
Unhandled Exception"com.fasterxml.jackson.databind.JsonMappingException: 49938 (through reference chain: com.asset.web.domain.ResponseCaseClass["asset"])
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:210)
```

Solution

Added the `com.fasterxml.jackson.datatype.jackson-datatype-jsr310` dependency and registered as a default jackson module

Result

case classes containing JSR310 datatypes are deserialized as expected.

This could also be handled by the workaround provided below.  Even-though it adds another dependency (sorry) i feel it's acceptable in order to reduce surprising behaviour like the exception above.

Workaround

``` scala
object JacksonModule extends FinatraJacksonModule {
    override val additionalJacksonModules = Seq(new JavaTimeModule)
}
```
