### PR TITLE
fix retryFuture to be able to set suprress

### DIFF
--- a/utils/src/main/scala/com/twitter/finatra/utils/RetryUtils.scala
+++ b/utils/src/main/scala/com/twitter/finatra/utils/RetryUtils.scala
@@ -23,12 +23,12 @@ object RetryUtils extends NewLogging {
     }
   }
 
-  def retryFuture[T](retryPolicy: RetryPolicy[Try[T]])(func: => Future[T]): Future[T] = {
+  def retryFuture[T](retryPolicy: RetryPolicy[Try[T]], suppress: Boolean = false)(func: => Future[T]): Future[T] = {
     exceptionsToFailedFuture(func) transform { result =>
       retryPolicy(result) match {
         case Some((sleepTime, nextPolicy)) =>
           scheduleFuture(sleepTime) {
-            retryMsg(sleepTime, result)
+            retryMsg(sleepTime, result, suppress)
             retryFuture(nextPolicy)(func)
           }
         case None =>
@@ -39,7 +39,7 @@ object RetryUtils extends NewLogging {
 
   /* Private */
 
-  private def retryMsg[T](sleepTime: Duration, result: Try[T], suppress: Boolean = false) {
+  private def retryMsg[T](sleepTime: Duration, result: Try[T], suppress: Boolean) {
     if (!suppress) {
       warn("Retrying " + result + " after " + sleepTime)
     }

--- a/utils/src/main/scala/com/twitter/finatra/utils/RetryUtils.scala
+++ b/utils/src/main/scala/com/twitter/finatra/utils/RetryUtils.scala
@@ -29,7 +29,7 @@ object RetryUtils extends NewLogging {
         case Some((sleepTime, nextPolicy)) =>
           scheduleFuture(sleepTime) {
             retryMsg(sleepTime, result, suppress)
-            retryFuture(nextPolicy)(func)
+            retryFuture(nextPolicy, suppress)(func)
           }
         case None =>
           Future.const(result)


### PR DESCRIPTION
Problem

RetryUtils#retry can switch warning log on and off by suppress parameter but
RetryUtils#retryFuture doesnt' have the parameter.

Solution

I've added a suppress parameter to retryFuture method with default false.

Result

RetryUtils#retryFuture can swtich warning log too.
