### PR TITLE
jackson: Handle joda exception in FinatraCaseClassDeserializer

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
@@ -13,6 +13,7 @@ import com.twitter.finatra.http.tests.integration.doeverything.main.exceptions._
 import com.twitter.finatra.http.tests.integration.doeverything.main.filters.{AppendToHeaderFilter, IdentityFilter, ForbiddenFilter}
 import com.twitter.finatra.http.tests.integration.doeverything.main.services.{ComplexServiceFactory, DoEverythingService, MultiService}
 import com.twitter.finatra.json.FinatraObjectMapper
+import com.twitter.finatra.json.tests.internal.CaseClassWithLocalDate
 import com.twitter.finatra.request.{QueryParam, RouteParam}
 import com.twitter.inject.annotations.Flag
 import com.twitter.util.Future
@@ -701,6 +702,10 @@ class DoEverythingController @Inject()(
       case _ =>
         response.methodNotAllowed
     }
+  }
+
+  post("/localDateRequest") { r: CaseClassWithLocalDate =>
+    response.ok
   }
 }
 

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -1705,4 +1705,11 @@ class DoEverythingServerFeatureTest extends FeatureTest {
       postBody = """{"value" : [{"foo" : "foo"}]}""",
       andExpect = BadRequest)
   }
+
+  "Bad request for deserialization of an invalid joda LocalDate" in {
+    server.httpPost(
+      "/localDateRequest",
+      postBody = """{"date" : "2016-11-32"}""",
+      andExpect = BadRequest)
+  }
 }

--- a/jackson/src/main/scala/com/twitter/finatra/json/FinatraObjectMapper.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/FinatraObjectMapper.scala
@@ -107,7 +107,7 @@ case class FinatraObjectMapper(
     try {
       objectMapper.convertValue[T](any)
     } catch {
-      case e: IllegalArgumentException =>
+      case e: IllegalArgumentException if e.getCause != null =>
         throw e.getCause
     }
   }
@@ -117,7 +117,7 @@ case class FinatraObjectMapper(
     try {
       objectMapper.convertValue(from, toValueType)
     } catch {
-      case e: IllegalArgumentException =>
+      case e: IllegalArgumentException if e.getCause != null =>
         throw e.getCause
     }
   }

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
@@ -126,8 +126,7 @@ private[finatra] class FinatraCaseClassDeserializer(
         case e: CaseClassValidationException =>
           addException(field, e)
 
-        // joda throws specific exception when a date is invalid
-        case e: org.joda.time.IllegalFieldValueException =>
+        case e: IllegalArgumentException =>
           val ex = CaseClassValidationException(
             PropertyPath.leaf(field.name),
             Invalid(

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializer.scala
@@ -126,6 +126,16 @@ private[finatra] class FinatraCaseClassDeserializer(
         case e: CaseClassValidationException =>
           addException(field, e)
 
+        // joda throws specific exception when a date is invalid
+        case e: org.joda.time.IllegalFieldValueException =>
+          val ex = CaseClassValidationException(
+            PropertyPath.leaf(field.name),
+            Invalid(
+              e.getMessage,
+              ErrorCode.Unknown))
+
+          addException(field, ex)
+
         case e: InvalidFormatException =>
           addException(
             field,

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala
@@ -11,7 +11,7 @@ import com.twitter.finatra.response.JsonCamelCase
 import com.twitter.finatra.validation.{InvalidValidationInternal, Min, NotEmpty, ValidationResult}
 import com.twitter.inject.Logging
 import javax.inject.{Inject, Named}
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, LocalDate}
 import scala.annotation.meta.param
 import scala.math.BigDecimal.RoundingMode
 
@@ -368,6 +368,9 @@ case class WithoutJsonPropertyAnnotation(foo: String)
 case class NamingStrategyJsonProperty(
   @JsonProperty longFieldName: String)
 
+
+case class CaseClassWithLocalDate(
+  date: LocalDate)
 
 package object internal {
 


### PR DESCRIPTION
Problem

parseConstructorValues method doesn't not handle joda
IllegalFieldValueException, this causes that the exception is
re-thrown leading to 'Internal Server Error' while deserializing
a request into a case class.

This happens when the case class have a LocalDate field and the
request argument is an invalid LocalDate.

Solution

Handle joda IllegalFieldValueException to not return an
'Internal Server Error' with meaningless feedback but 'Bad request'
having enough feedback for the client.
