### PR TITLE
force HTTP response header date format in English

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/filters/HttpResponseFilter.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/filters/HttpResponseFilter.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finatra.http.HttpHeaders
 import com.twitter.finatra.http.request.RequestUtils
 import com.twitter.util.{ScheduledThreadPoolTimer, Future}
-import java.util.TimeZone
+import java.util.{Locale, TimeZone}
 import javax.inject.Singleton
 import org.apache.commons.lang.time.FastDateFormat
 
@@ -19,7 +19,10 @@ import org.apache.commons.lang.time.FastDateFormat
 class HttpResponseFilter[R <: Request] extends SimpleFilter[R, Response] {
 
   // optimized
-  private val dateFormat = FastDateFormat.getInstance(HttpHeaders.RFC7231DateFormat, TimeZone.getTimeZone("GMT"))
+  private val dateFormat = FastDateFormat.getInstance(
+    HttpHeaders.RFC7231DateFormat,
+    TimeZone.getTimeZone("GMT"),
+    Locale.ENGLISH)
   @volatile private var currentDateValue: String = getCurrentDateValue()
   new ScheduledThreadPoolTimer(
     poolSize = 1,


### PR DESCRIPTION
Problem

see issue #351 and #312 

Solution

using English locale to init date formatter 

Result

Full compatible with RFC7231 date format in non-English locale country.

Questions

Last time I change the locale in test case into Chinese to make sure it can report error even in English country. But code reviewers thought it would affect other case and it shouldn't in a test case. So how we can make sure HttpResponse refactoring next time it could work expectly.

Fixes #351