### PR TITLE
Add built-in support for Scala Futures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val versions = new {
   val scroogeVersion = "4.12.0" + suffix
   val twitterserverVersion = "1.25.0" + suffix
   val utilVersion = "6.39.0" + suffix
+  val bijectionVersion = "0.9.4" + suffix
 
   val commonsCodec = "1.9"
   val commonsFileupload = "1.3.1"
@@ -504,6 +505,7 @@ lazy val http = project
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*ScalaObjectHandler.*;.*NonValidatingHttpHeadersResponse.*;com\\.twitter\\.finatra\\..*package.*",
     libraryDependencies ++= Seq(
       "com.github.spullara.mustache.java" % "compiler" % versions.mustache,
+      "com.twitter" %% "bijection-util" % versions.bijectionVersion,
       "com.twitter" %% "finagle-exp" % versions.finagleVersion,
       "com.twitter" %% "finagle-http" % versions.finagleVersion,
       "commons-fileupload" % "commons-fileupload" % versions.commonsFileupload,

--- a/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/CallbackConverter.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/CallbackConverter.scala
@@ -1,14 +1,18 @@
 package com.twitter.finatra.http.internal.marshalling
 
+import com.twitter.bijection.Conversion._
+import com.twitter.bijection.twitter_util.TwitterExecutionContext
+import com.twitter.bijection.twitter_util.UtilBijections.twitter2ScalaFuture
 import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.http._
 import com.twitter.finatra.http.response.{ResponseBuilder, StreamingResponse}
 import com.twitter.finatra.json.FinatraObjectMapper
 import com.twitter.finatra.json.internal.streaming.JsonStreamParser
 import com.twitter.io.Buf
-import com.twitter.util.Future
+import com.twitter.util.{Future, FuturePool}
 import javax.inject.Inject
 import org.jboss.netty.handler.codec.http.HttpResponseStatus
+import scala.concurrent.{Future => ScalaFuture}
 
 private[http] class CallbackConverter @Inject()(
   messageBodyManager: MessageBodyManager,
@@ -113,6 +117,20 @@ private[http] class CallbackConverter @Inject()(
         response.headerMap.add(Fields.ContentType, responseBuilder.jsonContentType)
         Future.value(response)
     }
+    else if (runtimeClassEq[ResponseType, ScalaFuture[_]]) {
+      implicit val ec = immediatePoolEc
+      def toTwitterFuture[A](in: ScalaFuture[A]) = in.as[Future[A]]
+
+      if (isScalaFutureOption[ResponseType]) {
+        val fn = (request: Request) =>
+          toTwitterFuture(requestCallback.asInstanceOf[Request => ScalaFuture[Option[_]]](request))
+        createResponseCallback(fn)
+      } else {
+        val fn = (request: Request) =>
+          toTwitterFuture(requestCallback.asInstanceOf[Request => ScalaFuture[_]](request))
+        createResponseCallback(fn)
+      }
+    }
     else {
       request: Request =>
         requestCallback(request) match {
@@ -153,4 +171,12 @@ private[http] class CallbackConverter @Inject()(
       typeArgs.size == 1 &&
       typeArgs.head.runtimeClass == classOf[Option[_]]
   }
+
+  private def isScalaFutureOption[T: Manifest]: Boolean = {
+    val typeArgs = manifest[T].typeArguments
+    runtimeClassEq[T, ScalaFuture[_]] &&
+        typeArgs.size == 1 &&
+        typeArgs.head.runtimeClass == classOf[Option[_]]  }
+
+  private[this] val immediatePoolEc = new TwitterExecutionContext(FuturePool.immediatePool)
 }

--- a/http/src/test/scala/com/twitter/finatra/http/tests/marshalling/CallbackConverterIntegrationTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/marshalling/CallbackConverterIntegrationTest.scala
@@ -12,6 +12,7 @@ import com.twitter.inject.modules.StatsReceiverModule
 import com.twitter.inject.{IntegrationTest, Mockito}
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util.{Await, Future}
+import scala.concurrent.{Future => ScalaFuture}
 
 class CallbackConverterIntegrationTest extends IntegrationTest with Mockito {
 
@@ -92,6 +93,75 @@ class CallbackConverterIntegrationTest extends IntegrationTest with Mockito {
       callbackConverter.convertToFutureResponse(futureSeqCarTrait),
       withBody = """[{"name":"Ford"}]""")
   }
+  
+  
+  // ScalaFuture
+  "ScalaFuture Some String" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSomeString),
+      withBody = "hello")
+  }
+
+  "ScalaFuture None String" in {
+    assertStatus(
+      callbackConverter.convertToFutureResponse(scalaFutureNoneString),
+      expectedStatus = Status.NotFound)
+  }
+
+  "ScalaFuture Some Product" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSomeProduct),
+      withBody = """{"name":"Ford"}""")
+  }
+
+  "ScalaFuture Some Trait" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSomeTrait),
+      withBody = """{"name":"Ford"}""")
+  }
+
+  "ScalaFuture String" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureString),
+      withBody = "bob")
+  }
+
+  "ScalaFuture Response" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureResponse),
+      withBody = "bob")
+  }
+
+  "ScalaFuture Some Response" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSomeResponse),
+      withBody = "bob")
+  }
+
+  "ScalaFuture None Response" in {
+    assertStatus(
+      callbackConverter.convertToFutureResponse(scalaFutureNoneResponse),
+      expectedStatus = Status.NotFound)
+  }
+
+  "ScalaFuture Seq String" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSeqString),
+      withBody = """["bob"]""")
+  }
+
+  "ScalaFuture Seq Car" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSeqCar),
+      withBody = """[{"name":"Ford"}]""")
+  }
+
+  "ScalaFuture Seq CarTrait" in {
+    assertOk(
+      callbackConverter.convertToFutureResponse(scalaFutureSeqCarTrait),
+      withBody = """[{"name":"Ford"}]""")
+  }
+
 
   "Object" in {
     assertOk(
@@ -253,6 +323,50 @@ class CallbackConverterIntegrationTest extends IntegrationTest with Mockito {
 
   def futureSeqCarTrait(request: Request): Future[Seq[CarTrait]] = {
     Future(Seq(ford))
+  }
+  
+  def scalaFutureSomeString(request: Request): ScalaFuture[Option[String]] = {
+    ScalaFuture.successful(Some("hello"))
+  }
+
+  def scalaFutureNoneString(request: Request): ScalaFuture[Option[String]] = {
+    ScalaFuture.successful(None)
+  }
+
+  def scalaFutureSomeProduct(request: Request): ScalaFuture[Option[Car]] = {
+    ScalaFuture.successful(Some(ford))
+  }
+
+  def scalaFutureSomeTrait(request: Request): ScalaFuture[Option[CarTrait]] = {
+    ScalaFuture.successful(Some(ford))
+  }
+
+  def scalaFutureString(request: Request): ScalaFuture[String] = {
+    ScalaFuture.successful("bob")
+  }
+
+  def scalaFutureResponse(request: Request): ScalaFuture[Response] = {
+    ScalaFuture.successful(okResponse)
+  }
+
+  def scalaFutureSomeResponse(request: Request): ScalaFuture[Option[Response]] = {
+    ScalaFuture.successful(Some(okResponse))
+  }
+
+  def scalaFutureNoneResponse(request: Request): ScalaFuture[Option[Response]] = {
+    ScalaFuture.successful(None)
+  }
+
+  def scalaFutureSeqString(request: Request): ScalaFuture[Seq[String]] = {
+    ScalaFuture.successful(Seq("bob"))
+  }
+
+  def scalaFutureSeqCar(request: Request): ScalaFuture[Seq[Car]] = {
+    ScalaFuture.successful(Seq(ford))
+  }
+
+  def scalaFutureSeqCarTrait(request: Request): ScalaFuture[Seq[CarTrait]] = {
+    ScalaFuture.successful(Seq(ford))
   }
 
   def asyncStreamRequestAndResponse(stream: AsyncStream[Int]): AsyncStream[String] = {


### PR DESCRIPTION
This introduces a default handler for Scala Futures, by translating them
into Twitter Futures, which are already handled natively.