### PR TITLE
scoverage, upgrade scoverage plugin dependency for scala 2.12.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys._
 import sbtunidoc.Plugin.UnidocKeys._
 import scala.language.reflectiveCalls
-import ScoverageSbtPlugin._
+import scoverage.ScoverageKeys
 
 concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,4 @@ addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % scroogeSbtPluginVersion)
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")
-// sbt-scoverage 1.3.3 and 1.3.5 have bugs that result in 2.10 tests not being run.
-// See https://github.com/scoverage/sbt-scoverage/issues/146
-// and https://github.com/scoverage/sbt-scoverage/issues/161
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")


### PR DESCRIPTION
Problem

Scoverage needs to be upgraded to support scala 2.12.1.
Additionally the scoverage upgrade should happen prior to other
modules adding 2.12 support.

Solution
  - Upgrade plugin version.
  - Add `import scoverage.ScoverageKeys` to build.sbt.

Result

scoverage is upgraded.

cc @mosesn 
Related to: #323