### PR TITLE
finatra, partial scala-2.12 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,14 +51,14 @@ lazy val versions = new {
   val logback = "1.1.7"
   val mockito = "1.9.5"
   val mustache = "0.8.18"
-  val nscalaTime = "1.6.0"
+  val nscalaTime = "2.16.0"
   val scalaCheck = "1.13.4"
   val scalaGuice = "4.1.0"
   val scalaTest = "3.0.0"
   val servletApi = "2.5"
   val slf4j = "1.7.21"
   val snakeyaml = "1.12"
-  val specs2 = "2.3.12"
+  val specs2 = "2.4.17"
 }
 
 lazy val scalaCompilerOptions = scalacOptions ++= Seq(
@@ -82,9 +82,11 @@ lazy val baseSettings = Seq(
     "org.scalatest" %% "scalatest" %  versions.scalaTest % "test",
     "org.specs2" %% "specs2" % versions.specs2 % "test"
   ),
+
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
-    Resolver.sonatypeRepo("snapshots")
+    Resolver.sonatypeRepo("snapshots"),
+    "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
   ),
   scalaCompilerOptions,
   javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
@@ -399,7 +401,6 @@ lazy val injectThriftClient = (project in file("inject/inject-thrift-client"))
   .settings(
     name := "inject-thrift-client",
     moduleName := "inject-thrift-client",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*\\.thriftscala.*;.*\\.thriftjava.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-exp" % versions.finagleVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -242,6 +242,7 @@ lazy val injectCore = (project in file("inject/inject-core"))
   .settings(
     name := "inject-core",
     moduleName := "inject-core",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-annotations" % versions.jackson,
       "com.google.guava" % "guava" % versions.guava,
@@ -280,6 +281,7 @@ lazy val injectModules = (project in file("inject/inject-modules"))
   .settings(
     name := "inject-modules",
     moduleName := "inject-modules",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion,
       "com.twitter" %% "util-stats" % versions.utilVersion
@@ -299,6 +301,7 @@ lazy val injectApp = (project in file("inject/inject-app"))
   .settings(
     name := "inject-app",
     moduleName := "inject-app",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.twitter" %% "util-core" % versions.utilVersion
     ),
@@ -323,6 +326,7 @@ lazy val injectServer = (project in file("inject/inject-server"))
   .settings(
     name := "inject-server",
     moduleName := "inject-server",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*Ports.*;.*FinagleBuildRevision.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-stats" % versions.finagleVersion,
@@ -347,6 +351,7 @@ lazy val injectSlf4j = (project in file("inject/inject-slf4j"))
   .settings(
     name := "inject-slf4j",
     moduleName := "inject-slf4j",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*LoggerModule.*;.*Slf4jBridgeUtility.*",
     libraryDependencies ++= Seq(
       "org.clapper" %% "grizzled-slf4j" % versions.grizzled,
@@ -363,6 +368,7 @@ lazy val injectRequestScope = (project in file("inject/inject-request-scope"))
   .settings(
     name := "inject-request-scope",
     moduleName := "inject-request-scope",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion
     )
@@ -375,6 +381,7 @@ lazy val injectThrift = (project in file("inject/inject-thrift"))
   .settings(
     name := "inject-thrift",
     moduleName := "inject-thrift",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*\\.thriftscala.*;.*\\.thriftjava.*",
     libraryDependencies ++= Seq(
       "com.twitter" % "libthrift" % versions.libThrift,
@@ -392,6 +399,7 @@ lazy val injectThriftClient = (project in file("inject/inject-thrift-client"))
   .settings(
     name := "inject-thrift-client",
     moduleName := "inject-thrift-client",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*\\.thriftscala.*;.*\\.thriftjava.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-exp" % versions.finagleVersion,
@@ -412,6 +420,7 @@ lazy val injectUtils = (project in file("inject/inject-utils"))
   .settings(
     name := "inject-utils",
     moduleName := "inject-utils",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion,
       "com.twitter" %% "finagle-mux" % versions.finagleVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -85,8 +85,7 @@ lazy val baseSettings = Seq(
 
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
-    Resolver.sonatypeRepo("snapshots"),
-    "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+    Resolver.sonatypeRepo("snapshots")
   ),
   scalaCompilerOptions,
   javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys._
 import sbtunidoc.Plugin.UnidocKeys._
 import scala.language.reflectiveCalls
-import ScoverageSbtPlugin._
+import scoverage.ScoverageKeys
 
 parallelExecution in ThisBuild := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,10 @@ lazy val baseSettings = Seq(
   javacOptions in doc ++= Seq("-source", "1.8")
 )
 
+// This is defined outside of the base settings for a partial upgrade where possible
+// until the other finatra dependencies are updated to support scala-2.12
+lazy val temporaryCrossScalaVersions = Seq("2.11.8", "2.12.1")
+
 lazy val publishSettings = Seq(
   publishMavenStyle := true,
   publishArtifact := true,
@@ -243,7 +247,7 @@ lazy val injectCore = (project in file("inject/inject-core"))
   .settings(
     name := "inject-core",
     moduleName := "inject-core",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-annotations" % versions.jackson,
       "com.google.guava" % "guava" % versions.guava,
@@ -282,7 +286,7 @@ lazy val injectModules = (project in file("inject/inject-modules"))
   .settings(
     name := "inject-modules",
     moduleName := "inject-modules",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion,
       "com.twitter" %% "util-stats" % versions.utilVersion
@@ -302,7 +306,7 @@ lazy val injectApp = (project in file("inject/inject-app"))
   .settings(
     name := "inject-app",
     moduleName := "inject-app",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     libraryDependencies ++= Seq(
       "com.twitter" %% "util-core" % versions.utilVersion
     ),
@@ -327,7 +331,7 @@ lazy val injectServer = (project in file("inject/inject-server"))
   .settings(
     name := "inject-server",
     moduleName := "inject-server",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*Ports.*;.*FinagleBuildRevision.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-stats" % versions.finagleVersion,
@@ -352,7 +356,7 @@ lazy val injectSlf4j = (project in file("inject/inject-slf4j"))
   .settings(
     name := "inject-slf4j",
     moduleName := "inject-slf4j",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*LoggerModule.*;.*Slf4jBridgeUtility.*",
     libraryDependencies ++= Seq(
       "org.clapper" %% "grizzled-slf4j" % versions.grizzled,
@@ -369,7 +373,7 @@ lazy val injectRequestScope = (project in file("inject/inject-request-scope"))
   .settings(
     name := "inject-request-scope",
     moduleName := "inject-request-scope",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion
     )
@@ -382,7 +386,7 @@ lazy val injectThrift = (project in file("inject/inject-thrift"))
   .settings(
     name := "inject-thrift",
     moduleName := "inject-thrift",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*\\.thriftscala.*;.*\\.thriftjava.*",
     libraryDependencies ++= Seq(
       "com.twitter" % "libthrift" % versions.libThrift,
@@ -420,7 +424,7 @@ lazy val injectUtils = (project in file("inject/inject-utils"))
   .settings(
     name := "inject-utils",
     moduleName := "inject-utils",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion,
       "com.twitter" %% "finagle-mux" % versions.finagleVersion,
@@ -456,7 +460,7 @@ lazy val utils = project
   .settings(
     name := "finatra-utils",
     moduleName := "finatra-utils",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     ScoverageKeys.coverageExcludedPackages := "<empty>;com\\.twitter\\.finatra\\..*package.*;.*ClassUtils.*;.*WrappedValue.*;.*DeadlineValues.*;.*RichBuf.*;.*RichByteBuf.*",
     libraryDependencies ++= Seq(
       "com.google.inject" % "guice" % versions.guice,
@@ -567,7 +571,7 @@ lazy val slf4j = project
   .settings(
     name := "finatra-slf4j",
     moduleName := "finatra-slf4j",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     ScoverageKeys.coverageExcludedPackages := "<empty>;org\\.slf4j\\..*package.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "util-core" % versions.utilVersion
@@ -581,7 +585,7 @@ lazy val thrift = project
   .settings(
     name := "finatra-thrift",
     moduleName := "finatra-thrift",
-    crossScalaVersions := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions := temporaryCrossScalaVersions,
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*\\.thriftscala.*;.*\\.thriftjava.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -457,6 +457,7 @@ lazy val utils = project
   .settings(
     name := "finatra-utils",
     moduleName := "finatra-utils",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;com\\.twitter\\.finatra\\..*package.*;.*ClassUtils.*;.*WrappedValue.*;.*DeadlineValues.*;.*RichBuf.*;.*RichByteBuf.*",
     libraryDependencies ++= Seq(
       "com.google.inject" % "guice" % versions.guice,
@@ -567,6 +568,7 @@ lazy val slf4j = project
   .settings(
     name := "finatra-slf4j",
     moduleName := "finatra-slf4j",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;org\\.slf4j\\..*package.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "util-core" % versions.utilVersion
@@ -580,6 +582,7 @@ lazy val thrift = project
   .settings(
     name := "finatra-thrift",
     moduleName := "finatra-thrift",
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
     ScoverageKeys.coverageExcludedPackages := "<empty>;.*\\.thriftscala.*;.*\\.thriftjava.*",
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % versions.finagleVersion,

--- a/inject/inject-core/src/test/scala/org/specs2/matcher/ScalaTestExpectations.scala
+++ b/inject/inject-core/src/test/scala/org/specs2/matcher/ScalaTestExpectations.scala
@@ -26,7 +26,7 @@ trait ScalaTestExpectations extends Expectations {
     new Expectable(() => t) {
       override def check[S >: T](r: MatchResult[S]): MatchResult[S] = {
         r match {
-          case f@MatchFailure(ok, ko, _, _) =>
+          case f@MatchFailure(ok, ko, _, _, _) =>
             throw new TestFailedException(f.message, f.exception, 0) // We throw a ScalaTest exception here
           case _ =>
             ()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,4 @@ addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % scroogeSbtPluginVersion)
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")
-// sbt-scoverage 1.3.3 and 1.3.5 have bugs that result in 2.10 tests not being run.
-// See https://github.com/scoverage/sbt-scoverage/issues/146
-// and https://github.com/scoverage/sbt-scoverage/issues/161
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")


### PR DESCRIPTION
Problem

Finatra does not publish scala-2.12 compatible artifacts.  Additionally
some portions of finatra are not able to be upgraded due to
various dependencies lacking support for scala-2.12.

Solution

Partially upgrade finatra modules to use crossScalaVersions where
the upgrade does not affect those other finatra modules
such as http, jackson, and thrift-client.

Result

It is possible to publish scala-2.12 compatible artifacts for
finatra-slf4j, finatra-utils, finatra-inject, and finatra-thrift

cc: @cacoco @mosesn 
Related: #323 , #376 