### PR TITLE
Add support for a single nesting level of case-classes-inside-objects

### DIFF
--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/reflection/ScalaType.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/reflection/ScalaType.scala
@@ -5,7 +5,13 @@ import scala.tools.scalap.scalax.rules.scalasig.TypeRefType
 private[json] case class ScalaType(
   typeRefType: TypeRefType) {
 
-  private val path = typeRefType.symbol.path
+  private val path = {
+    val sym = typeRefType.symbol
+
+    // Class loading for object-contained types uses 'Parent$Child' rather than 'Parent.Child' paths.
+    // TODO(virusdave): Migrate the fix upstream so that arbitrary nesting levels will be supported.
+    sym.parent.map(p => p.path + (if (p.isModule) "$" else ".")).getOrElse("") + sym.name
+  }
 
   /* Public */
 

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/FinatraObjectMapperTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/FinatraObjectMapperTest.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.annotations.CamelCaseMapper
 import com.twitter.finatra.json.internal.caseclass.exceptions.{CaseClassMappingException, CaseClassValidationException, JsonInjectionNotSupportedException, RequestFieldInjectionNotSupportedException}
 import com.twitter.finatra.json.modules.FinatraJacksonModule
-import com.twitter.finatra.json.tests.internal.Obj.NestedCaseClassInObject
+import com.twitter.finatra.json.tests.internal.Obj.{NestedCaseClassInObject, NestedCaseClassInObjectWithNestedCaseClassInObjectParam}
 import com.twitter.finatra.json.tests.internal._
 import com.twitter.finatra.json.tests.internal.internal.{SimplePersonInPackageObject, SimplePersonInPackageObjectWithoutConstructorParams}
 import com.twitter.finatra.json.{FinatraObjectMapper, JsonDiff}
@@ -710,6 +710,18 @@ class FinatraObjectMapperTest extends FeatureSpec with Matchers with Logging {
           "id": "foo"
         }
         """) should equal(NestedCaseClassInObject(id = "foo"))
+    }
+
+    scenario("case class nested within an object with member that is also a case class in an object") {
+      parse[NestedCaseClassInObjectWithNestedCaseClassInObjectParam](
+        """
+        {
+          "nested": {
+            "id": "foo"
+          }
+        }
+        """
+      ) should equal(NestedCaseClassInObjectWithNestedCaseClassInObjectParam(nested = NestedCaseClassInObject(id = "foo")))
     }
 
     case class NestedCaseClassInClass(id: String)

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala
@@ -207,6 +207,9 @@ object Obj {
 
   case class NestedCaseClassInObject(id: String)
 
+  case class NestedCaseClassInObjectWithNestedCaseClassInObjectParam(
+    nested: NestedCaseClassInObject)
+
 }
 
 case class WrappedValueInt(value: Int)


### PR DESCRIPTION
Problem

Case classes with members that are themselves object-nested case classes fail with a runtime class loading exception.
See the tests for a clear example.

Solution
Use the correct path style for object-nested classes.

Result

One level of nesting is now supported.
NOTE that an upstream fix is really required for arbitrary nesting.  I'll pursue this, but it might take some time to be accepted and published.