### PR TITLE
Add support for single-level nesting through companion objects

### DIFF
--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala
@@ -212,6 +212,11 @@ object Obj {
 
 }
 
+class TypeAndCompanion
+object TypeAndCompanion {
+  case class NestedCaseClassInCompanion(id: String)
+}
+
 case class WrappedValueInt(value: Int)
   extends WrappedValue[Int]
 


### PR DESCRIPTION
Problem

The fix for "case classes nested one level inside of objects" didn't work if that object was a companion object, since earlier code would "find" the companion object's class instead of the object itself.

Solution

If we're trying to find an case-class-in-object, don't attempt to use the object's companion class.

Result

This now works for a single level of nesting through companion objects.
However, i'm convinced that this case class code as a whole is extremely brittle and unlikely to work for any particular cases that aren't exactly captured by unit test scenarios.  It should probably be completely rewritten, and i'll probably take a whack at this larger problem at some point.