### PR TITLE
finatra-http: Increase composability and flexibility of RouteDSL

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/RouteBuilder.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/RouteBuilder.scala
@@ -1,9 +1,10 @@
 package com.twitter.finatra.http
 
-import com.twitter.finagle.http.{Method => HttpMethod, RouteIndex}
+import com.twitter.finagle.http.{RouteIndex, Method => HttpMethod}
 import com.twitter.finatra.http.internal.marshalling.CallbackConverter
 import com.twitter.finatra.http.internal.routing.Route
 import com.twitter.inject.Injector
+import java.lang.annotation.Annotation
 
 private[http] class RouteBuilder[RequestType: Manifest, ResponseType: Manifest](
   method: HttpMethod,
@@ -12,7 +13,8 @@ private[http] class RouteBuilder[RequestType: Manifest, ResponseType: Manifest](
   admin: Boolean,
   index: Option[RouteIndex],
   callback: RequestType => ResponseType,
-  routeDsl: RouteDSL) {
+  annotations: Array[Annotation],
+  routeDsl: RouteContext) {
 
   def build(callbackConverter: CallbackConverter, injector: Injector) = Route(
     name = name,
@@ -21,7 +23,7 @@ private[http] class RouteBuilder[RequestType: Manifest, ResponseType: Manifest](
     admin = admin,
     index = index,
     callback = callbackConverter.convertToFutureResponse(callback),
-    annotations = routeDsl.annotations,
+    annotations = annotations,
     requestClass = manifest[RequestType].runtimeClass,
     responseClass = manifest[ResponseType].runtimeClass,
     routeFilter = routeDsl.buildFilter(injector),

--- a/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
@@ -4,35 +4,74 @@ import com.twitter.finagle.Filter
 import com.twitter.finagle.http.Method._
 import com.twitter.finagle.http.{Method, RouteIndex}
 import com.twitter.inject.Injector
+import com.twitter.util.Var
 import scala.collection.mutable.ArrayBuffer
 
-private[http] trait RouteDSL { self =>
+private[http] case class RouteContext(prefix: String, buildFilter: (Injector) => HttpFilter)
 
+private trait MutableRouteState {
+  private[http] val context: RouteContext = RouteContext(
+    prefix = "",
+    buildFilter = (_) => Filter.identity
+  )
+
+  private[http] lazy val contextRef = Var(context)
+}
+
+private class FilteredDSL[FilterType <: HttpFilter : Manifest] extends RouteDSL {
+  override private[http] val context = {
+    val curr = contextRef()
+    curr.copy(buildFilter = getBuildFilterFunc(curr.buildFilter))
+  }
+
+  def apply(fn: => Unit): Unit = withContext(context)(fn)
+
+  protected def getBuildFilterFunc(currFunc: (Injector) => HttpFilter): (Injector) => HttpFilter = {
+    (injector: Injector) => currFunc(injector).andThen(injector.instance[FilterType])
+  }
+
+  override private[http] def contextWrapper[T](f: => T): T = withContext(context)(f)
+}
+
+private class PrefixedDSL(prefix: String) extends RouteDSL {
+  override private[http] val context = {
+    val curr = contextRef()
+    curr.copy(prefix = curr.prefix + prefix)
+  }
+
+  def apply(fn: => Unit): Unit = withContext(context)(fn)
+
+  override private[http] def contextWrapper[T](f: => T): T = withContext(context)(f)
+}
+
+private[http] trait RouteDSL extends MutableRouteState { self =>
   private[http] val routeBuilders = ArrayBuffer[RouteBuilder[_, _]]()
   private[http] val annotations = getClass.getDeclaredAnnotations
-  /* Mutable State */
-  private[this] var routePrefix = ""
 
-  private[http] def buildFilter(injector: Injector): HttpFilter = Filter.identity
-
-  def filter[FilterType <: HttpFilter : Manifest] = new RouteDSL {
-    override val routeBuilders = self.routeBuilders
-    override val annotations = self.annotations
-    override def buildFilter(injector: Injector) = self.buildFilter(injector).andThen(injector.instance[FilterType])
+  def filter[FilterType <: HttpFilter : Manifest]: FilteredDSL[FilterType] = contextWrapper {
+    new FilteredDSL[FilterType] {
+      override private[http] val routeBuilders = self.routeBuilders
+      override private[http] val annotations = self.annotations
+      override private[http] lazy val contextRef = self.contextRef
+    }
   }
 
-  def filter(next: HttpFilter) = new RouteDSL {
-    override val routeBuilders = self.routeBuilders
-    override def buildFilter(injector: Injector) = self.buildFilter(injector).andThen(next)
+  def filter(next: HttpFilter): FilteredDSL[HttpFilter] = contextWrapper {
+    new FilteredDSL[HttpFilter] {
+      override private[http] val routeBuilders = self.routeBuilders
+      override private[http] val annotations = self.annotations
+      override private[http] lazy val contextRef = self.contextRef
+      override protected def getBuildFilterFunc(currFunc: (Injector) => HttpFilter): (Injector) => HttpFilter = {
+        (injector: Injector) => currFunc(injector).andThen(next)
+      }
+    }
   }
 
-  def prefix(value: String)(fn: => Unit): Unit = {
-    val previous = routePrefix
-    routePrefix = value
-    try {
-      fn
-    } finally {
-      routePrefix = previous
+  def prefix(value: String): PrefixedDSL = contextWrapper {
+    new PrefixedDSL(value) {
+      override private[http] val routeBuilders = self.routeBuilders
+      override private[http] val annotations = self.annotations
+      override private[http] lazy val contextRef = self.contextRef
     }
   }
 
@@ -99,6 +138,18 @@ private[http] trait RouteDSL { self =>
     index: Option[RouteIndex] = None)(callback: RequestType => ResponseType): Unit =
     add(AnyMethod, route, name, admin, index, callback)
 
+  /* Protected */
+
+  // A function that wraps another and sets any contexts, if necessary
+  private[http] def contextWrapper[T](f: => T): T = f
+
+  // Executes a block with a given RouteContext
+  private[http] def withContext[T](ctx: RouteContext)(f: => T): T = {
+    val orig = contextRef()
+    contextRef() = ctx
+    try f finally contextRef() = orig
+  }
+
   /* Private */
 
   private def add[RequestType: Manifest, ResponseType: Manifest](
@@ -107,12 +158,12 @@ private[http] trait RouteDSL { self =>
     name: String,
     admin: Boolean,
     index: Option[RouteIndex],
-    callback: RequestType => ResponseType) = {
-    routeBuilders += new RouteBuilder(method, prefixRoute(route), name, admin, index, callback, self)
+    callback: RequestType => ResponseType) = contextWrapper {
+    routeBuilders += new RouteBuilder(method, prefixRoute(route), name, admin, index, callback, annotations, contextRef().copy())
   }
 
   private def prefixRoute(route: String): String = {
-    routePrefix match {
+    contextRef().prefix match {
       case prefix if prefix.nonEmpty && prefix.startsWith("/") => s"$prefix$route"
       case prefix if prefix.nonEmpty && !prefix.startsWith("/") => s"/$prefix$route"
       case _ => route

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
@@ -62,6 +62,38 @@ class DoEverythingController @Inject()(
     post("/foo") { request: Request =>
       "bar"
     }
+
+    filter[ForbiddenFilter].get("/forbiddenByFilter") { request: Request =>
+      "ok!"
+    }
+
+    filter(new AppendToHeaderFilter("appended" , "1")).
+      filter(new AppendToHeaderFilter("appended" , "2")).
+      get("/appendMultiplePrefixed") { request: Request =>
+        request.headerMap("appended")
+    }
+
+    filter(new AppendToHeaderFilter("freestyle", "bang")) {
+      get("/freestyleWithHeader") { request: Request =>
+        request.headerMap("freestyle")
+      }
+    }
+  }
+
+  prefix("/1.1") {
+    prefix("/waterfall") {
+      prefix("/users") {
+        get("/") { request: Request =>
+          "ok!"
+        }
+      }
+    }
+  }
+
+  filter[ForbiddenFilter].prefix("/1.1") {
+    get("/forbiddenByFilterPrefilter"){ request: Request =>
+      "ok!"
+    }
   }
 
   get("/forwarded") { request: Request =>

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -111,6 +111,42 @@ class DoEverythingServerFeatureTest extends FeatureTest {
     response.contentType should equal(Some(MediaType.PLAIN_TEXT_UTF_8.toString))
   }
 
+  test("/forbiddenByFilter (prefixed)") {
+    server.httpGet(
+      "/1.1/forbiddenByFilter",
+      andExpect = Forbidden
+    )
+  }
+
+  test("/forbiddenByFilter (prefixed outer)") {
+    server.httpGet(
+      "/1.1/forbiddenByFilterPrefilter",
+      andExpect = Forbidden
+    )
+  }
+
+  test("/appendMultiplePrefixed (prefixed)") {
+    server.httpGet(
+      "/1.1/appendMultiplePrefixed",
+      withBody = "12"
+    )
+  }
+
+  test("/freestyleWithHeader (prefixed)") {
+    server.httpGet(
+      "/1.1/freestyleWithHeader",
+      withBody = "bang"
+    )
+  }
+
+  test("/1.1/waterfall/users (cascading prefixes)") {
+    server.httpGet(
+      "/1.1/waterfall/users/",
+      andExpect = Ok,
+      withBody = "ok!"
+    )
+  }
+
   test("GET /bytearray") {
     val response = server.httpGet(
       "/bytearray")

--- a/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTests.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTests.scala
@@ -1,0 +1,96 @@
+package com.twitter.finatra.http.tests.routing
+
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Filter, Service, SimpleFilter}
+import com.twitter.finatra.http.{FilteredDSL, PrefixedDSL, RouteDSL}
+import com.twitter.inject.Test
+import com.twitter.inject.app.TestInjector
+import com.twitter.util.{Await, Future}
+import org.scalatest.OptionValues
+
+// So we can test injection
+class NormalTestFilter extends TestFilter("request" -> "true", "response" -> "true")
+
+class TestFilter(
+  appendToRequestMap: (String, String),
+  appendToResponseMap: (String, String)
+) extends SimpleFilter[Request, Response] {
+  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    request.headerMap.add(appendToRequestMap._1, appendToRequestMap._2)
+    service(request).map(response => {
+      response.headerMap.add(appendToResponseMap._1, appendToResponseMap._2)
+      response
+    })
+  }
+}
+
+class RouteDSLTests extends Test with OptionValues {
+  val identityService = Service.mk[Request, Response](req => Future.value(Response(req)))
+
+  test("RouteDSL") {
+    val injector = TestInjector()
+    val dsl = new RouteDSL {}
+
+    // We verify that calling the default buildFilter function returns an identity filter
+    dsl.context.buildFilter(null) shouldEqual Filter.identity
+    dsl.context.buildFilter(injector) shouldEqual Filter.identity
+  }
+
+  // Simple test to verify that the build filter is set appropriately in a new FilteredDSL
+  test("FilteredDSL sets build filter") {
+    val injector = TestInjector()
+    val dsl = new FilteredDSL[NormalTestFilter]()
+
+    val req = Request()
+    // Verify that we changed the default
+    val filter1 = dsl.context.buildFilter(injector)
+    val filter2 = new NormalTestFilter()
+    val res1 = Await.result(filter1(req, identityService))
+    val res2 = Await.result(filter2(req, identityService))
+
+    res1.headerMap shouldEqual res2.headerMap
+  }
+
+  test("FilteredDSL composes build filters") {
+    val injector = TestInjector()
+    val dsl = new FilteredDSL[NormalTestFilter]().filter(new TestFilter("request2" -> "yes", "response2" -> "yes"))
+
+    val req = Request()
+
+    // Verify that we changed the default
+    val filter1 = dsl.context.buildFilter(injector)
+    val filter2 = new NormalTestFilter() andThen new TestFilter("request2" -> "yes", "response2" -> "yes")
+
+    val res1 = Await.result(filter1(req, identityService))
+    val res2 = Await.result(filter2(req, identityService))
+
+    res1.headerMap shouldEqual res2.headerMap
+  }
+
+  test("PrefixedDSL should update the context prefix") {
+    val injector = TestInjector()
+    val dsl = new PrefixedDSL("v1")
+
+    dsl.context.prefix shouldEqual "v1"
+    dsl.context.buildFilter(injector) shouldEqual Filter.identity
+  }
+
+  test("PrefixedDSL should chain to more prefixes") {
+    val dsl = new PrefixedDSL("v1").prefix("/api")
+
+    dsl.context.prefix shouldEqual "v1/api"
+  }
+
+  test("PrefixedDSL should chain to FilteredDSL") {
+    val injector = TestInjector()
+    val dsl = new PrefixedDSL("v1").filter[NormalTestFilter]
+
+    dsl.context.prefix shouldEqual "v1"
+
+    val req = Request()
+    val filter = dsl.context.buildFilter(injector)
+    val res = Await.result(filter(req, identityService))
+
+    res.headerMap("response") shouldEqual "true"
+  }
+}


### PR DESCRIPTION
Problem:

Today, the routing DSL supports two composable pieces (prefix and
filter). These are implemented under different paradigms; filter
produces a new Route context while prefix takes a block and uses a var
to track the prefix.

There are a few issues / unexpected behaviors that result:
* Prefixes are not composable
* Filtered routes inside of prefixes don't work (https://github.com/twitter/finatra/issues/392)
* Filtered prefixes are not supported
* The syntax is rigid between the two

Solution

The changes here revist the structure of RouteDSL and unify the way
routes are defined in Controllers to increase flexibility and remove
unexpected behavior and bugs. Namely, mutable state is now centralized
to a twitter-util Var cell and an API is laid out for creating
"specialized" RouteDSL contexts (FilteredDSL and PrefixedDSL).

This allows for a great amount of flexibility for the user when defining
routes as well as increasing the extensibility of the DSL for future
additions. For example:

Filtered prefixes:
```scala
filter[MyFilter].prefix("/v1/prefix") {
    // ...
}
```

Cascading prefixes:
```scala
prefix("/v1") {
  prefix("/foo") {
    prefix("/bar") {
     // ..
    }
  }
}
```

"Freestyle" filter syntax:

```scala
filter[MyFilter] {
  // ...
}
```