### PR TITLE
Make JsonPatchExceptionMapper public

### DIFF
--- a/http/src/main/scala/com/twitter/finatra/http/jsonpatch/JsonPatchExceptionMapper.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/jsonpatch/JsonPatchExceptionMapper.scala
@@ -6,7 +6,7 @@ import com.twitter.finatra.http.response.{ErrorsResponse, ResponseBuilder}
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-private[http] class JsonPatchExceptionMapper @Inject()(
+class JsonPatchExceptionMapper @Inject()(
   response: ResponseBuilder)
   extends ExceptionMapper[JsonPatchException] {
 


### PR DESCRIPTION
Problem

The json patch [documentation][1] describes how to set up twitter-server
to make use of json patch requests. The docs explain that one must register the
JsonPatchExceptionMapper, but outside of the `http` package this is not possible
as the class has a `private[http]` modifier. My assumption is that the docs are
correct.

[1]: https://twitter.github.io/finatra/user-guide/http/requests.html#json-patch-requests

Solution

Remove the `private[http]` modifier of JsonPatchExceptionMapper making it
possible to import and use.