### PR TITLE
[Finatra 2.8.0 migration issue] Change http client create method to Http.client.newService

### DIFF
--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/RichHttpClient.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/RichHttpClient.scala
@@ -8,7 +8,7 @@ object RichHttpClient {
   /* Public */
 
   def newClientService(dest: String): Service[Request, Response] = {
-    Http.newClient(dest).toService
+    Http.client.newService(dest)
   }
 
   def newSslClientService(sslHostname: String, dest: String): Service[Request, Response] = {


### PR DESCRIPTION
Problem

After upgrade Finatra *2.8.0* from 2.6.0 ESTABLESHED is not closed. 
```
2017-03-20 21:24:07,296 - ERROR finagle/netty3-5 ThrowableExceptionMapper  slf4j.scala:137 Unhandled Exception
org.jboss.netty.channel.ChannelException: Failed to open a socket.
        at org.jboss.netty.channel.socket.nio.NioClientSocketChannel.newSocket(NioClientSocketChannel.java:43)
        at org.jboss.netty.channel.socket.nio.NioClientSocketChannel.<init>(NioClientSocketChannel.java:82)
        at org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory.newChannel(NioClientSocketChannelFactory.java:212)
        at org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory.newChannel(NioClientSocketChannelFactory.java:82)
        at com.twitter.finagle.netty3.Netty3Transporter$$anonfun$makeNewChannel$1.apply(Netty3Transporter.scala:244)
        at com.twitter.finagle.netty3.Netty3Transporter$$anonfun$makeNewChannel$1.apply(Netty3Transporter.scala:244)
        at com.twitter.finagle.netty3.Netty3Transporter.com$twitter$finagle$netty3$Netty3Transporter$$newConfiguredChannel(Netty3Transporter.scala:387)
        at com.twitter.finagle.netty3.Netty3Transporter$$anonfun$5.apply(Netty3Transporter.scala:394)
        at com.twitter.finagle.netty3.Netty3Transporter$$anonfun$5.apply(Netty3Transporter.scala:394)
        at com.twitter.finagle.netty3.ChannelConnector.apply(Netty3Transporter.scala:47)
        at com.twitter.finagle.netty3.Netty3Transporter.apply(Netty3Transporter.scala:396)
        at com.twitter.finagle.netty3.Netty3Transporter$$anon$3.apply(Netty3Transporter.scala:143)
        at com.twitter.finagle.client.StdStackClient$$anon$1$$anonfun$1.apply(StackClient.scala:560)
        at com.twitter.finagle.client.StdStackClient$$anon$1$$anonfun$1.apply(StackClient.scala:560)
        at com.twitter.finagle.ServiceFactory$$anon$9.apply(Service.scala:205)
        at com.twitter.finagle.Filter$AndThen$$anon$3.apply(Filter.scala:149)
        at com.twitter.finagle.Filter$$anon$2.apply(Filter.scala:99)
        at com.twitter.finagle.service.FailFastFactory.apply(FailFastFactory.scala:208)
        at com.twitter.finagle.pool.CachingPool.apply(CachingPool.scala:58)
        at com.twitter.finagle.pool.WatermarkPool.apply(WatermarkPool.scala:144)
        at com.twitter.finagle.service.FailureAccrualFactory.apply(FailureAccrualFactory.scala:346)
        at com.twitter.finagle.service.ExceptionRemoteInfoFactory.apply(ExceptionRemoteInfoFactory.scala:71)
        at com.twitter.finagle.ServiceFactoryProxy.apply(Service.scala:220)
        at com.twitter.finagle.Filter$$anon$2.apply(Filter.scala:99)
        at com.twitter.finagle.Filter$$anon$2.apply(Filter.scala:99)
        at com.twitter.finagle.Filter$$anon$2.apply(Filter.scala:99)
        at com.twitter.finagle.Filter$$anon$2.apply(Filter.scala:99)
        at com.twitter.finagle.Filter$$anon$2.apply(Filter.scala:99)
        at com.twitter.finagle.loadbalancer.LoadBalancerFactory$StackModule$$anon$3.apply(LoadBalancerFactory.scala:181)
        at com.twitter.finagle.ServiceFactoryProxy.apply(Service.scala:220)
      ....
```

![connection-leak](http://i.imgur.com/eg8rcFk.png)


Solution

[Change http client factory method.](https://github.com/twitter/finatra/blob/develop/httpclient/src/main/scala/com/twitter/finatra/httpclient/RichHttpClient.scala#L11)

from
```scala
def newClientService(dest: String): Service[Request, Response] = {
  Http.newClient(dest).toService
}
```
to 
```scala
def newClientService(dest: String): Service[Request, Response] = {
  Http.client.newService(dest)
}
```


Result

### Connection is stable and no more increased!

![image](https://cloud.githubusercontent.com/assets/1866157/24135340/8af866fa-0e4c-11e7-8299-8f2c016530ec.png)
