### PR TITLE
inject-app add missing files to TestJar and TestJarSources 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -331,7 +331,9 @@ lazy val injectModules = (project in file("inject/inject-modules"))
 lazy val injectAppTestJarSources =
   Seq("com/twitter/inject/app/Banner",
     "com/twitter/inject/app/EmbeddedApp",
+    "com/twitter/inject/app/modules",
     "com/twitter/inject/app/InjectionServiceModule",
+    "com/twitter/inject/app/InjectionServiceWithAnnotationModule",
     "com/twitter/inject/app/StartupTimeoutException",
     "com/twitter/inject/app/TestInjector")
 lazy val injectApp = (project in file("inject/inject-app"))


### PR DESCRIPTION
Problem

inject-app_2.11-2.9.0-tests-sources.jar doesn't include module.scala

before
```
com
└── twitter
    └── inject
        └── app
            ├── Banner.scala
            ├── EmbeddedApp.scala
            ├── StartupTimeoutException.scala
            └── TestInjector.scala
```

Solution

Add module.scala instead of InjectionServiceModule.scala
InjectionServiceModule was deleted in
https://github.com/twitter/finatra/commit/2a8c53c6b86bec7

Result

after

```
com
└── twitter
    └── inject
        └── app
            ├── Banner.scala
            ├── EmbeddedApp.scala
            ├── StartupTimeoutException.scala
            ├── TestInjector.scala
            └── modules.scala
```