### PR TITLE
Change the constructor parameter of HttpClientException

### DIFF
--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClientException.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClientException.scala
@@ -4,7 +4,7 @@ import scala.util.control.NoStackTrace
 import com.twitter.finagle.http.Status
 
 class HttpClientException(
-  status: Status,
+  val status: Status,
   msg: String)
   extends Exception(msg)
   with NoStackTrace


### PR DESCRIPTION
Problem
When using the HttpClient.executeJson method, if the status of the response differs from expectedStatus, an HttpClientException is returned. The status and contentString of the response are used when creating an HttpClientException, but the value of status is actually inaccessible.

Solution
Change the constructor parameter of HttpClientException.