### PR TITLE
inject-app add InjectionServiceWithAnnotationModule.class to TestJar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,6 +332,7 @@ lazy val injectAppTestJarSources =
   Seq("com/twitter/inject/app/Banner",
     "com/twitter/inject/app/EmbeddedApp",
     "com/twitter/inject/app/InjectionServiceModule",
+    "com/twitter/inject/app/InjectionServiceWithAnnotationModule",
     "com/twitter/inject/app/StartupTimeoutException",
     "com/twitter/inject/app/TestInjector")
 lazy val injectApp = (project in file("inject/inject-app"))


### PR DESCRIPTION
This PR is related to https://github.com/twitter/finatra/pull/398#issuecomment-290897710

Problem

inject-app_2.11-2.9.0-tests.jar doesn't include InjectionServiceWithAnnotationModule.class

This may cause following exception.

```scala
[info]   Cause: java.lang.ClassNotFoundException: com.twitter.inject.app.InjectionServiceWithAnnotationModule
[info]   at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
[info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
[info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
[info]   at com.twitter.inject.app.TestInjector.bind(TestInjector.scala:118)
```

I think, we might be want to have both `InjectionServiceModule.class` and `InjectionServiceWithAnnotationModule.class`.

```
└── twitter
    └── inject
        └── app
            ├── Banner$.class
            ├── Banner.class
            ├── EmbeddedApp.class
            ├── InjectionServiceModule.class
            ├── InjectionServiceWithAnnotationModule.class
            ├── StartupTimeoutException.class
            ├── TestInjector$.class
            └── TestInjector.class
```

Solution

add InjectionServiceWithAnnotationModule.class to jar
