### PR TITLE
update sbt-unidoc 0.3.2 => 0.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import sbt.Keys._
-import sbtunidoc.Plugin.UnidocKeys._
 import scala.language.reflectiveCalls
 import scoverage.ScoverageKeys
 
@@ -235,10 +234,10 @@ def mappingContainsAnyPath(mapping: (File, String), paths: Seq[String]): Boolean
 }
 
 lazy val root = (project in file("."))
+  .enablePlugins(ScalaUnidocPlugin)
   .settings(baseSettings)
   .settings(buildSettings)
   .settings(publishSettings)
-  .settings(unidocSettings)
   .settings(
     organization := "com.twitter",
     moduleName := "finatra-root",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ val scroogeSbtPluginVersion =
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % scroogeSbtPluginVersion)
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.2")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.20")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")


### PR DESCRIPTION
Problem

sbt-unidoc 0.3.2 is not autoplugin but, 0.4.0 is autoplugin

Solution

update sbt-unidoc

Solution

We can use sbt-unidoc as autoplugin
https://github.com/sbt/sbt-unidoc/releases/tag/v0.4.0