### PR TITLE
[WIP] Add support for Mockito 2 in FeatureTest.

### DIFF
--- a/inject/inject-core/src/test/scala/com/twitter/inject/IntegrationTestMixin.scala
+++ b/inject/inject-core/src/test/scala/com/twitter/inject/IntegrationTestMixin.scala
@@ -54,9 +54,7 @@ trait IntegrationTestMixin
 
   protected def hasBoundFields: Boolean = boundFields.nonEmpty
 
-  /* Private */
-
-  private lazy val mockObjects = {
+  protected lazy val mockObjects = {
     val mockUtil = new MockUtil()
     for {
       field <- boundFields
@@ -65,6 +63,16 @@ trait IntegrationTestMixin
     } yield fieldValue
   }
 
+  protected lazy val boundFields = {
+    for {
+      field <- getDeclaredFieldsRespectingInheritance(getClass)
+      if hasBindAnnotation(field)
+      _ = field.setAccessible(true)
+    } yield field
+  }
+
+  /* Private */
+
   private lazy val resettableObjects = {
     for {
       field <- boundFields
@@ -72,14 +80,6 @@ trait IntegrationTestMixin
       _ = field.setAccessible(true)
       fieldValue = field.get(this)
     } yield fieldValue.asInstanceOf[Resettable]
-  }
-
-  private lazy val boundFields = {
-    for {
-      field <- getDeclaredFieldsRespectingInheritance(getClass)
-      if hasBindAnnotation(field)
-      _ = field.setAccessible(true)
-    } yield field
   }
 
   private def hasBindAnnotation(field: Field): Boolean = {

--- a/inject/inject-core/src/test/scala/com/twitter/inject/Mockito2.scala
+++ b/inject/inject-core/src/test/scala/com/twitter/inject/Mockito2.scala
@@ -1,0 +1,19 @@
+package com.twitter.inject
+
+import org.mockito.ArgumentMatchers
+import org.specs2.matcher.ScalaTestExpectations
+
+/**
+ * Provides Specs2 Mockito 2 syntax sugar for ScalaTest.
+ *
+ * This is a drop-in replacement for org.specs2.mock.Mockito. Don't use
+ * org.specs2.mock.Mockito directly. Otherwise, match failures won't be
+ * propagated up as ScalaTest test failures.
+ */
+trait Mockito2
+  extends Mockito {
+
+  override protected def meq[T](obj: T): T = {
+    ArgumentMatchers.eq(obj)
+  }
+}

--- a/inject/inject-server/src/test/scala/com/twitter/inject/server/FeatureTestMockito2.scala
+++ b/inject/inject-server/src/test/scala/com/twitter/inject/server/FeatureTestMockito2.scala
@@ -1,0 +1,41 @@
+package com.twitter.inject.server
+
+import com.twitter.inject.Test
+import org.mockito.internal.util.MockUtil
+
+/**
+ * Extensible abstract test class which uses the [[org.scalatest.FunSuite]] ScalaTest
+ * style and mixes in the [[com.twitter.inject.server.FeatureTestMixin]] trait.
+ *
+ * Example usage:
+ *
+ * {{{
+ *   class MyFooTest
+ *     extends FeatureTestMockito2
+ *     with Mockito2 {
+ *
+ *     override val server = new EmbeddedTwitterServer(
+ *       twitterServer = new MyTwitterServer)
+ *
+ *     test("TestServer#endpoint should do what it's supposed to do") {
+ *       ...
+ *     }
+ *   }
+ * }}}
+ *
+ * @see [[org.scalatest.FunSuite FunSuite]]
+ * @see [[com.twitter.inject.Test Finatra Test Class]]
+ * @see [[com.twitter.inject.server.FeatureTestMixin Finatra FeatureTestMixin]]
+ */
+abstract class FeatureTestMockito2
+  extends Test
+  with FeatureTestMixin {
+
+  override protected lazy val mockObjects = {
+    for {
+      field <- boundFields
+      fieldValue = field.get(this)
+      if MockUtil.isMock(fieldValue)
+    } yield fieldValue
+  }
+}

--- a/inject/inject-server/src/test/scala/com/twitter/inject/server/tests/FeatureTestMockito2Test.scala
+++ b/inject/inject-server/src/test/scala/com/twitter/inject/server/tests/FeatureTestMockito2Test.scala
@@ -1,0 +1,15 @@
+package com.twitter.inject.server.tests
+
+import com.twitter.inject.server.{EmbeddedTwitterServer, FeatureTestMockito2, TwitterServer}
+import org.scalatest.Tag
+
+class FeatureTestMockito2Test extends FeatureTestMockito2 {
+
+  override val server =
+    new EmbeddedTwitterServer(new TwitterServer {})
+    .bind[String]("helloworld")
+
+  test("feature test") {
+    server.injector.instance[String] should be("helloworld")
+  }
+}


### PR DESCRIPTION
Problem

`FeatureTest` does not support using Mockito 2 as described in #403.

Solution

Mockito 2 made some breaking API changes:
* deprecating `org.mockito.Matchers` in favor of
  `org.mockito.ArgumentMatchersMatchers`
* `org.mockito.internal.util.MockUtil.isMock` became a static method.

Make the affected attributes protected to allow them to be overridden in
Mockito 2 specific classes.

This is a first stab at tackling this issue, but I'm not sure this is the best approach.
Also, I don't know how to easily integrate this with the current Mockito (version 1.9.5) dependency.

Result

Allows to use Mockito 2, by using the new classes `inject/inject-core/src/test/scala/com/twitter/inject/Mockito2.scala` and `inject/inject-server/src/test/scala/com/twitter/inject/server/FeatureTestMockito2.scala`.