### PR TITLE
Fix JSON serialization of scala.util.Either type for Scala 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file. Note that `
 
 ### Fixed
 
+* finatra-jackson: Fix JSON deserialization of scala.util.Either type in FinatraObjectMapper
+  for Scala 2.12.
+
 ### Closed
 
 ## [finatra-2.10.0](https://github.com/twitter/finatra/tree/finatra-2.10.0) (2017-04-20)

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializers.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/FinatraCaseClassDeserializers.scala
@@ -23,6 +23,7 @@ private[finatra] class FinatraCaseClassDeserializers(
     else if (OPTION.isAssignableFrom(cls)) false
     else if (LIST.isAssignableFrom(cls)) false
     else if (cls.getName.startsWith("scala.Tuple")) false
+    else if (cls.getName.startsWith("scala.util.Either")) false
     else true
   }
 }

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/FinatraObjectMapperTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/FinatraObjectMapperTest.scala
@@ -206,6 +206,14 @@ class FinatraObjectMapperTest extends Test with Logging {
     person should equal(steve)
   }
 
+  test("simple tests#generate then parse Either type") {
+    type T = Either[String, Int]
+    val l: T = Left("Q?")
+    val r: T = Right(42)
+    assertJson(l, """{"l":"Q?"}""")
+    assertJson(r, """{"r":42}""")
+  }
+
   test("simple tests#generate then parse nested case class") {
     val origCar = Car(1, CarMake.Ford, "Explorer", Seq(steve, steve))
     val carJson = generate(origCar)


### PR DESCRIPTION
Fix JSON deserialization of scala.util.Either type with FinatarObjectMapper 
for Scala 2.12.

Problem

In Scala 2.12 Either type extends Product trait. This breaks case class deserializer type check in 
c.t.finatra.json.internal.caseclass.jackson.FinatraCaseClassDeserializers. 

Solution

I added explicit condition for Either type, so case class deserializer is not 
selected and EitherDeserializer is selected.

Result

Either object can be converted to JSON and back from JSON to Either object
using FinatraObjectMapper as it was in Scala 2.11.
