### PR TITLE
inject-utils: use call-by-name param in RichOption methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file. Note that `
   use the DefaultTimer for the backupRequestFilter method param instead of the 
   HashedWheelTimer. ``PHAB_ID=D88025``
 
+* inject-utils: (BREAKING API CHANGE) RichOption toFutureOrFail, toTryOrFail, and toFutureOrElse signature
+  changed to take the fail or else parameter by name.
+
 ### Fixed
 
 ### Closed

--- a/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/option.scala
+++ b/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/option.scala
@@ -8,14 +8,14 @@ object option {
   object RichOption {
 
     //In companion so can be called from httpfuture.scala
-    def toFutureOrFail[A](option: Option[A], throwable: Throwable) = {
+    def toFutureOrFail[A](option: Option[A], throwable: => Throwable) = {
       option match {
         case Some(returnVal) => Future.value(returnVal)
         case None => Future.exception(throwable)
       }
     }
 
-    def toTryOrFail[A](option: Option[A], throwable: Throwable) = {
+    def toTryOrFail[A](option: Option[A], throwable: => Throwable) = {
       option match {
         case Some(returnVal) => Return(returnVal)
         case None => Throw(throwable)
@@ -24,20 +24,20 @@ object option {
   }
 
   implicit class RichOption[A](val self: Option[A]) extends AnyVal {
-    def toFutureOrFail(throwable: Throwable) = {
+    def toFutureOrFail(throwable: => Throwable) = {
       RichOption.toFutureOrFail(self, throwable)
     }
 
-    def toTryOrFail(throwable: Throwable): Try[A] = {
+    def toTryOrFail(throwable: => Throwable): Try[A] = {
       RichOption.toTryOrFail(self, throwable)
     }
 
-    def toFutureOrElse(orElse: A): Future[A] = self match {
+    def toFutureOrElse(orElse: => A): Future[A] = self match {
       case Some(returnVal) => Future.value(returnVal)
       case None => Future.value(orElse)
     }
 
-    def toFutureOrElse(orElse: Future[A]): Future[A] = self match {
+    def toFutureOrElse(orElse: => Future[A])(implicit dummy: DummyImplicit): Future[A] = self match {
       case Some(returnVal) => Future.value(returnVal)
       case None => orElse
     }

--- a/inject/inject-utils/src/test/scala/com/twitter/inject/tests/conversions/OptionsConversionsTest.scala
+++ b/inject/inject-utils/src/test/scala/com/twitter/inject/tests/conversions/OptionsConversionsTest.scala
@@ -7,26 +7,40 @@ import com.twitter.util.{Future, Throw, Try}
 class OptionsConversionsTest extends Test {
 
   test("RichOption#toFutureOrFail when Some") {
-    assertFuture(Some(1).toFutureOrFail(TestException), Future(1))
+    var evaluated = false
+    assertFuture(
+      Some(1).toFutureOrFail({ evaluated = true ; TestException }),
+      Future(1))
+    assert(!evaluated)
   }
   test("RichOption#toFutureOrFail when None") {
     assertFailedFuture[TestException](None.toFutureOrFail(TestException))
   }
   test("RichOption#toTryOrFail when Some") {
-    Some(1).toTryOrFail(TestException) should equal(Try(1))
+    var evaluated = false
+    Some(1).toTryOrFail({ evaluated = true; TestException }) should equal(Try(1))
+    assert(!evaluated)
   }
   test("RichOption#toTryOrFail when None") {
     None.toTryOrFail(TestException) should equal(Throw(TestException))
   }
   test("RichOption#toFutureOrElse when Some") {
-    assertFuture(Some(1).toFutureOrElse(2), Future(1))
+    var evaluated = false
+    assertFuture(
+      Some(1).toFutureOrElse({ evaluated = true ; 2 }),
+      Future(1))
+    assert(!evaluated)
   }
   test("RichOption#toFutureOrElse when None") {
     val noneInt: Option[Int] = None
     assertFuture(noneInt.toFutureOrElse(2), Future(2))
   }
   test("RichOption#toFutureOrElse with Future when Some") {
-    assertFuture(Some(1).toFutureOrElse(Future(2)), Future(1))
+    var evaluated = false
+    assertFuture(
+      Some(1).toFutureOrElse(Future({ evaluated = true ; 2 })),
+      Future(1))
+    assert(!evaluated)
   }
   test("RichOption#toFutureOrElse with Future when None") {
     val noneInt: Option[Int] = None


### PR DESCRIPTION
Problem

Unlike Option#getOrElse, RichOption methods don’t take the else param
by name, leading to surprising evaluation of side-effects when used
(such as the else-case future being created).

Solution

Change the signature to call-by-name. One overload of toFutureOrElse
now takes a DummyImplicit due to no longer having a distinct signature
after erasure.
