### PR TITLE
Update typo in example

### DIFF
--- a/doc/src/sphinx/user-guide/json/index.rst
+++ b/doc/src/sphinx/user-guide/json/index.rst
@@ -64,7 +64,7 @@ For example,
 .. code:: scala
 
     // custom deserializer
-    class FooDeserializer extends com.fasterxml.jackson.databind.JsonDerializer[Foo] {
+    class FooDeserializer extends com.fasterxml.jackson.databind.JsonDeserializer[Foo] {
       override def deserialize(...)
     }
 


### PR DESCRIPTION
The code snippet as provided doesn’t run, because there's no such thing as a "JsonDerializer". This fixes the example.