### PR TITLE
Fix the URL for the "Getting Started" page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Finatra is a lightweight framework for building fast, testable, scala applicatio
 
 ## Documentation
 
-To get started, see the [Getting Started](https://twitter.github.io/finatra/user-guide/getting-started/index.html) section of our [User Guide][user-guide] to get up and running. Or check out the specific sections for building [HTTP](https://twitter.github.io/finatra/user-guide/http/server.html) or [Thrift](https://twitter.github.io/finatra/user-guide/thrift/server.html) servers.
+To get started, see the [Getting Started](https://twitter.github.io/finatra/user-guide/index.html#getting-started) section of our [User Guide][user-guide] to get up and running. Or check out the specific sections for building [HTTP](https://twitter.github.io/finatra/user-guide/http/server.html) or [Thrift](https://twitter.github.io/finatra/user-guide/thrift/server.html) servers.
 
 ## Examples
 


### PR DESCRIPTION
## Problem

The link to "Getting Started" in README.me goes to a 404. The docs must have been reorganized recently.

## Solution

Updated the URL from https://twitter.github.io/finatra/user-guide/getting-started/index.html to https://twitter.github.io/finatra/user-guide/index.html#getting-started
