### PR TITLE
httpclient: Document HttpClient hostname param

### DIFF
--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClient.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClient.scala
@@ -10,8 +10,16 @@ import com.twitter.inject.utils.RetryUtils
 import com.twitter.util.{Future, Try}
 
 /**
- * A simple HTTP client
- */
+  * A simple HTTP client.
+  *
+  * @param hostname - hostname of the destination server. set if the server requires a Host header
+  * @param httpService - [[com.twitter.finagle.Service]] that takes a
+  *                    [[com.twitter.finagle.http.Request]] and returns a
+  *                    [[com.twitter.finagle.http.Response]] future
+  * @param retryPolicy - optional retry policy if the service fails to get a successful response
+  * @param defaultHeaders - headers to add to every request
+  * @param mapper - object mapper
+  */
 class HttpClient(
   hostname: String = "",
   httpService: Service[Request, Response],

--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClient.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClient.scala
@@ -12,10 +12,9 @@ import com.twitter.util.{Future, Try}
 /**
   * A simple HTTP client.
   *
-  * @param hostname - hostname of the destination server. set if the server requires a Host header
-  * @param httpService - [[com.twitter.finagle.Service]] that takes a
-  *                    [[com.twitter.finagle.http.Request]] and returns a
-  *                    [[com.twitter.finagle.http.Response]] future
+  * @note some servers won't handle requests properly if the Host header is not set
+  * @param hostname - the hostname that will be used for the Host header. leave as default or set as "" to not set a Host header
+  * @param httpService - underlying [[com.twitter.finagle.Service]]
   * @param retryPolicy - optional retry policy if the service fails to get a successful response
   * @param defaultHeaders - headers to add to every request
   * @param mapper - object mapper

--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/modules/HttpClientModule.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/modules/HttpClientModule.scala
@@ -14,6 +14,8 @@ abstract class HttpClientModule extends TwitterModule {
 
   def dest: String
 
+  // used to set the Host header in the requests
+  // override if the dest requires a Host header
   def hostname: String = ""
 
   def retryPolicy: Option[RetryPolicy[Try[Response]]] = None


### PR DESCRIPTION
**Problem**

`HttpClient` has a `hostname` field that must be set when the server it is requesting required the Host header. 

**Solution**

Simply document `HttpClient.scala` and `HttpClientModule.scala` so future users know when the need to set this optional parameter.