### PR TITLE
Fixup Broken Links

### DIFF
--- a/doc/src/sphinx/user-guide/http/controllers.rst
+++ b/doc/src/sphinx/user-guide/http/controllers.rst
@@ -57,7 +57,7 @@ Here we are adding *by type* allowing the framework to handle class instantiatio
 Controllers and Routing
 -----------------------
 
-Routes are defined in a `Sinatra <http://www.sinatrarb.com/>`__-style syntax which consists of an HTTP method, a URL matching pattern and an associated callback function. The callback function can accept either a `c.t.finagle.http.Request <https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/Request.scala>`__ or a custom case-class that declaratively represents the request you wish to accept. In addition, the callback can return any type that can be converted into a `c.t.finagle.http.Response <https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/Response.scala>`__.
+Routes are defined in a `Sinatra <http://www.sinatrarb.com/>`__-style syntax which consists of an HTTP method, a URL matching pattern and an associated callback function. The callback function can accept either a `c.t.finagle.http.Request <https://github.com/twitter/finagle/blob/develop/finagle-base-http/src/main/scala/com/twitter/finagle/http/Request.scala>`__ or a custom case-class that declaratively represents the request you wish to accept. In addition, the callback can return any type that can be converted into a `c.t.finagle.http.Response <https://github.com/twitter/finagle/blob/develop/finagle-base-http/src/main/scala/com/twitter/finagle/http/Response.scala>`__.
 
 When Finatra receives an HTTP request, it will scan all registered controllers **in the order they are added** and dispatch the request to the **first matching** route starting from the top of each controller then invoking the matching route's associated callback function.
 

--- a/doc/src/sphinx/user-guide/http/filters.rst
+++ b/doc/src/sphinx/user-guide/http/filters.rst
@@ -214,7 +214,7 @@ Using `c.t.finagle.http.Request#ctx`
 
 Above we saw how to seed classes to the Finatra Request scope using a `Provider[T]`.
 
-However, we recommend *not* seeding with a request-scope `Provider[T]` but instead using Finagle's `c.t.finagle.http.Request#ctx <https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/Request.scala#L33>`__.
+However, we recommend *not* seeding with a request-scope `Provider[T]` but instead using Finagle's `c.t.finagle.http.Request#ctx <https://github.com/twitter/finagle/blob/develop/finagle-base-http/src/main/scala/com/twitter/finagle/http/Request.scala#L33>`__.
 Internally, we generally use the `Request#ctx` over `Provider[T]` even though we use Guice extensively.
 
 To use the `Request#ctx` technique, first create a `RecordSchema <https://github.com/twitter/util/blob/develop/util-collection/src/main/scala/com/twitter/collection/RecordSchema.scala#L6>`__ `request field <https://github.com/twitter/finagle/blob/develop/finagle-base-http/src/main/scala/com/twitter/finagle/http/Request.scala#L34>`__, a context and a filter which can set the context:

--- a/doc/src/sphinx/user-guide/http/requests.rst
+++ b/doc/src/sphinx/user-guide/http/requests.rst
@@ -40,7 +40,7 @@ The custom `UsersRequest` case class can then be used as the route callback's in
       request
     }
 
-The case class field names should match the request parameters or use the `@JsonProperty <https://github.com/FasterXML/jackson-annotations#annotations-for-renaming-properties>`__ annotation to specify the JSON field name in the case class (see: `example <https://github.com/twitter/finatra/blob/develop/jackson/src/test/scala/com/twitter/finatra/tests/json/internal/ExampleCaseClasses.scala#L141>`__).
+The case class field names should match the request parameters or use the `@JsonProperty <https://github.com/FasterXML/jackson-annotations#annotations-for-renaming-properties>`__ annotation to specify the JSON field name in the case class (see: `example <https://github.com/twitter/finatra/blob/develop/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/ExampleCaseClasses.scala#L141>`__).
 
 A `PropertyNamingStrategy <https://fasterxml.github.io/jackson-databind/javadoc/2.3.0/com/fasterxml/jackson/databind/PropertyNamingStrategy.html>`__ can be configured to handle common name substitutions (e.g. snake\_case or camelCase). By default, snake\_case is
 used (defaults are set in `FinatraJacksonModule <https://github.com/twitter/finatra/tree/master/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala>`__).

--- a/doc/src/sphinx/user-guide/http/responses.rst
+++ b/doc/src/sphinx/user-guide/http/responses.rst
@@ -202,7 +202,7 @@ Cookies, like Headers, are read from request and can set on the response via the
     }
 
 
-Advanced cookies are supported by creating and configuring `c.t.finagle.http.Cookie <https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/Cookie.scala>`__ objects:
+Advanced cookies are supported by creating and configuring `c.t.finagle.http.Cookie <https://github.com/twitter/finagle/blob/develop/finagle-base-http/src/main/scala/com/twitter/finagle/http/Cookie.scala>`__ objects:
 
 .. code:: scala
 

--- a/doc/src/sphinx/user-guide/logging/index.rst
+++ b/doc/src/sphinx/user-guide/logging/index.rst
@@ -40,6 +40,6 @@ trait which can be mixed into any object or class:
 
 This trait is a wrapper with some added utility over the `c.t.util.logging.Logging <https://github.com/twitter/util/blob/develop/util-slf4j-api/src/main/scala/com/twitter/util/logging/Logging.scala>`__.
 
-Scala users should prefer using the logging methods of the `c.t.inject.Logging <https://github.com/twitter/finatra/blob/develop/inject/inject-core/src/main/scala/com/twitter/inject/Logging.scala>`__ trait (as opposed to directly accessing the Logger instance) as these methods use "call-by-name" parameters.
+Scala users should prefer using the logging methods of the `c.t.inject.Logging <https://github.com/twitter/finatra/blob/develop/inject/inject-slf4j/src/main/scala/com/twitter/inject/Logging.scala>`__ trait (as opposed to directly accessing the Logger instance) as these methods use "call-by-name" parameters.
 
 For more information see the `scaladocs <https://twitter.github.io/finatra/scaladocs/index.html#com.twitter.inject.Logging>`__ for `c.t.inject.Logging` or the `util-slf4j-api README <https://github.com/twitter/util/blob/develop/util-slf4j-api/README.md>`__.

--- a/doc/src/sphinx/user-guide/testing/index.rst
+++ b/doc/src/sphinx/user-guide/testing/index.rst
@@ -281,7 +281,7 @@ Working with Mocks
 provides `Specs2 <https://etorreborre.github.io/specs2/>`__ Mockito
 syntax sugar for `ScalaTest <http://www.scalatest.org/>`__.
 
-This is a drop-in replacement for `org.specs2.mock.Mockito <http://etorreborre.github.io/specs2/guide/SPECS2-3.0/org.specs2.guide.UseMockito.html>`__. We encourage you to not use `org.specs2.mock.Mockito` directly. Otherwise, match failures will not be propagated up as ScalaTest test failures.
+This is a drop-in replacement for `org.specs2.mock.Mockito <http://etorreborre.github.io/specs2/guide/SPECS2-3.9.1/org.specs2.guide.UseMockito.html>`__. We encourage you to not use `org.specs2.mock.Mockito` directly. Otherwise, match failures will not be propagated up as ScalaTest test failures.
 
 See the next few sections on how you can use mocks in testing with either `Override Modules`_ or using `Embedded Server #bind[T] <#embedded-server-bind-t>`__.
 


### PR DESCRIPTION
Problem

Links were broken in the docs.

Solution

Updated the links.

Result

No functional changes but the documentation is more up to date.
