### PR TITLE
Upgrade specs2 to 3.9.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val versions = new {
   val servletApi = "2.5"
   val slf4j = "1.7.21"
   val snakeyaml = "1.12"
-  val specs2 = "2.4.17"
+  val specs2 = "3.9.5"
 }
 
 lazy val scalaCompilerOptions = scalacOptions ++= Seq(

--- a/examples/benchmark-server/build.sbt.for_release_branches_only
+++ b/examples/benchmark-server/build.sbt.for_release_branches_only
@@ -43,4 +43,4 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalatest" %% "scalatest" %  "3.0.0" % "test",
-  "org.specs2" %% "specs2-mock" % "2.4.17" % "test")
+  "org.specs2" %% "specs2-mock" % "3.9.5" % "test")

--- a/examples/hello-world-heroku/build.sbt.for_release_branches_only
+++ b/examples/hello-world-heroku/build.sbt.for_release_branches_only
@@ -49,4 +49,4 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalatest" %% "scalatest" %  "3.0.0" % "test",
-  "org.specs2" %% "specs2-mock" % "2.4.17" % "test")
+  "org.specs2" %% "specs2-mock" % "3.9.5" % "test")

--- a/examples/hello-world/build.sbt.for_release_branches_only
+++ b/examples/hello-world/build.sbt.for_release_branches_only
@@ -45,4 +45,4 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalatest" %% "scalatest" %  "3.0.0" % "test",
-  "org.specs2" %% "specs2-mock" % "2.4.17" % "test")
+  "org.specs2" %% "specs2-mock" % "3.9.5" % "test")

--- a/examples/java-http-server/build.sbt.for_release_branches_only
+++ b/examples/java-http-server/build.sbt.for_release_branches_only
@@ -56,5 +56,5 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalatest" %% "scalatest" %  "3.0.0" % "test",
-  "org.specs2" %% "specs2-mock" % "2.4.17" % "test",
+  "org.specs2" %% "specs2-mock" % "3.9.5" % "test",
   "com.novocode" % "junit-interface" % "0.11" % Test)

--- a/examples/tiny-url/src/test/scala/com/twitter/tiny/TinyUrlServerFeatureTest.scala
+++ b/examples/tiny-url/src/test/scala/com/twitter/tiny/TinyUrlServerFeatureTest.scala
@@ -6,7 +6,6 @@ import com.twitter.inject.Mockito
 import com.twitter.inject.server.FeatureTest
 import com.twitter.tiny.domain.http.PostUrlResponse
 import com.twitter.tiny.services._
-import org.mockito.Matchers.anyObject
 import redis.clients.jedis.{Jedis => JedisClient}
 import scala.util.Random
 
@@ -18,8 +17,8 @@ class TinyUrlServerFeatureTest extends FeatureTest with Mockito {
       .bind[JedisClient](mockJedisClient)
 
   test("Server#return shortened url") {
-    mockJedisClient.get(anyObject[String]()) returns null
-    mockJedisClient.set(anyObject[String](), anyObject[String]()) returns "OK"
+    mockJedisClient.get(any[String]()) returns null
+    mockJedisClient.set(any[String](), any[String]()) returns "OK"
 
     val port = server.httpExternalPort
     val path =
@@ -42,8 +41,8 @@ class TinyUrlServerFeatureTest extends FeatureTest with Mockito {
   }
 
   test("Server#resolve shortened url") {
-    mockJedisClient.get(anyObject[String]()) returns null
-    mockJedisClient.set(anyObject[String](), anyObject[String]()) returns "OK"
+    mockJedisClient.get(any[String]()) returns null
+    mockJedisClient.set(any[String](), any[String]()) returns "OK"
 
     val response =
       server.httpPostJson[PostUrlResponse](path = "/url", postBody = """
@@ -52,7 +51,7 @@ class TinyUrlServerFeatureTest extends FeatureTest with Mockito {
           }
         """, andExpect = Created)
 
-    mockJedisClient.get(anyObject[String]()) returns "http://www.google.com"
+    mockJedisClient.get(any[String]()) returns "http://www.google.com"
 
     server.httpGet(
       path = response.tinyUrl.substring(response.tinyUrl.lastIndexOf("/")),
@@ -75,7 +74,7 @@ class TinyUrlServerFeatureTest extends FeatureTest with Mockito {
         EncodingRadix
       )
 
-    mockJedisClient.get(anyObject[String]()) returns null
+    mockJedisClient.get(any[String]()) returns null
 
     server.httpGet(path = s"/$id", andExpect = NotFound)
   }

--- a/examples/twitter-clone/build.sbt.for_release_branches_only
+++ b/examples/twitter-clone/build.sbt.for_release_branches_only
@@ -44,4 +44,4 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalatest" %% "scalatest" %  "3.0.0" % "test",
-  "org.specs2" %% "specs2-mock" % "2.4.17" % "test")
+  "org.specs2" %% "specs2-mock" % "3.9.5" % "test")

--- a/examples/web-dashboard/build.sbt.for_release_branches_only
+++ b/examples/web-dashboard/build.sbt.for_release_branches_only
@@ -52,4 +52,4 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalatest" %% "scalatest" %  "3.0.0" % "test",
-  "org.specs2" %% "specs2-mock" % "2.4.17" % "test")
+  "org.specs2" %% "specs2-mock" % "3.9.5" % "test")

--- a/http/src/test/scala/com/twitter/finatra/http/tests/marshalling/MessageBodyManagerTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/marshalling/MessageBodyManagerTest.scala
@@ -5,9 +5,8 @@ import com.twitter.finatra.http.internal.marshalling.MessageBodyManager
 import com.twitter.finatra.http.marshalling.MessageBodyReader
 import com.twitter.finatra.http.modules.{MessageBodyModule, MustacheModule}
 import com.twitter.finatra.json.modules.FinatraJacksonModule
-import com.twitter.inject.Test
+import com.twitter.inject.{Mockito, Test}
 import com.twitter.inject.app.TestInjector
-import org.specs2.mock.Mockito
 
 class MessageBodyManagerTest extends Test with Mockito {
 

--- a/http/src/test/scala/com/twitter/finatra/http/tests/request/MultiParamsTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/request/MultiParamsTest.scala
@@ -5,10 +5,9 @@ import com.twitter.finagle.{http => finagle}
 import com.twitter.finagle.http.codec.HttpCodec
 import com.twitter.finatra.http.fileupload.MultipartItem
 import com.twitter.finatra.http.request.RequestUtils
-import com.twitter.inject.Test
+import com.twitter.inject.{Mockito, Test}
 import org.apache.commons.fileupload.util.FileItemHeadersImpl
 import org.apache.commons.io.IOUtils
-import org.specs2.mock.Mockito
 import scala.collection.JavaConverters._
 
 class MultiParamsTest extends Test with Mockito {

--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/InMemoryHttpServiceTest.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/InMemoryHttpServiceTest.scala
@@ -5,9 +5,8 @@ import com.twitter.finatra.httpclient.test.{
   InMemoryHttpService,
   PostRequestWithIncorrectBodyException
 }
-import com.twitter.inject.Test
+import com.twitter.inject.{Mockito, Test}
 import com.twitter.util.Await
-import org.specs2.mock.Mockito
 
 class InMemoryHttpServiceTest extends Test with Mockito {
   val inMemoryHttpService = new InMemoryHttpService()

--- a/inject/inject-core/src/test/scala/com/twitter/inject/IntegrationTestMixin.scala
+++ b/inject/inject-core/src/test/scala/com/twitter/inject/IntegrationTestMixin.scala
@@ -55,11 +55,10 @@ trait IntegrationTestMixin extends SuiteMixin with TestMixin { this: Suite =>
   /* Private */
 
   private lazy val mockObjects = {
-    val mockUtil = new MockUtil()
     for {
       field <- boundFields
       fieldValue = field.get(this)
-      if mockUtil.isMock(fieldValue)
+      if MockUtil.isMock(fieldValue)
     } yield fieldValue
   }
 

--- a/inject/inject-core/src/test/scala/com/twitter/inject/Mockito.scala
+++ b/inject/inject-core/src/test/scala/com/twitter/inject/Mockito.scala
@@ -1,6 +1,6 @@
 package com.twitter.inject
 
-import org.mockito.Matchers
+import org.mockito.ArgumentMatchers
 import org.specs2.matcher.ScalaTestExpectations
 
 /**
@@ -13,7 +13,7 @@ import org.specs2.matcher.ScalaTestExpectations
 trait Mockito extends org.specs2.mock.Mockito with ScalaTestExpectations with Logging {
 
   protected def meq[T](obj: T): T = {
-    Matchers.eq(obj)
+    ArgumentMatchers.eq(obj)
   }
 
   protected def eqManifest[T: Manifest]: Manifest[T] = {


### PR DESCRIPTION
Problem

The version of specs2 in this project is old, so we should upgrade it.

Solution

Upgrade it to 3.9.5.

Result

Upgrading it is completed.