### PR TITLE
Fixed issue with json object spanning 2 bufs

### DIFF
--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/ByteBufferUtils.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/ByteBufferUtils.scala
@@ -8,7 +8,7 @@ import java.nio.ByteBuffer
 private[finatra] object ByteBufferUtils extends Logging {
 
   //TODO: Optimize/Refactor
-  def append(byteBuffer: ByteBuffer, buf: Buf): ByteBuffer = {
+  def append(byteBuffer: ByteBuffer, buf: Buf, pos: Int): ByteBuffer = {
     val byteBufferBuf = {
       val byteBufferCopy = byteBuffer.duplicate()
       byteBufferCopy.position(0)
@@ -16,7 +16,9 @@ private[finatra] object ByteBufferUtils extends Logging {
     }
 
     val combinedBufs = byteBufferBuf.concat(buf)
-    Buf.ByteBuffer.Shared.extract(combinedBufs)
+    val result = Buf.ByteBuffer.Shared.extract(combinedBufs)
+    result.position(pos)
+    result
   }
 
   def debugBuffer(byteBuffer: ByteBuffer) = {

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/JsonArrayChunker.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/JsonArrayChunker.scala
@@ -15,24 +15,27 @@ private[finatra] class JsonArrayChunker extends Logging {
   private[finatra] var done = false
   private[finatra] var openBraces = 0
   private var byteBuffer = ByteBuffer.allocate(0)
+  private var position = 0
 
   /* Public */
 
   def decode(inputBuf: Buf): Seq[Buf] = {
     assertDecode(inputBuf)
-    byteBuffer = ByteBufferUtils.append(byteBuffer, inputBuf)
+    byteBuffer = ByteBufferUtils.append(byteBuffer, inputBuf,position)
 
     val result = ArrayBuffer[Buf]()
 
     while (byteBuffer.hasRemaining) {
       ByteBufferUtils.debugBuffer(byteBuffer)
       val currByte = byteBuffer.get
+      position = byteBuffer.position
 
-      if (!arrayFound && currByte == '[') {
+      if (!arrayFound && currByte == '[' && openBraces == 0) {
         debug("ArrayFound. Openbraces = 1")
         parsingState = InsideArray
-        openBraces = 1
+        openBraces += 1
         byteBuffer = byteBuffer.slice()
+        position = 0
       } else if (!arrayFound && Character.isWhitespace(currByte.toChar)) {
         debug("Skip space")
       } else {
@@ -43,6 +46,7 @@ private[finatra] class JsonArrayChunker extends Logging {
           if (currByte == ']') {
             debug("Done")
             done = true
+            //return None
           }
         }
       }
@@ -69,7 +73,7 @@ private[finatra] class JsonArrayChunker extends Logging {
         parsingState = InsideString
       }
       // If the double quote wasn't escaped then this is the end of a string.
-      else if (in.get(in.position - 1) != '\\') {
+      else if (in.get(in.position - 2) != '\\') {
         debug("State = Parsing")
         parsingState = Normal
       }
@@ -84,6 +88,7 @@ private[finatra] class JsonArrayChunker extends Logging {
     val copyBuf = Buf.ByteBuffer.Shared(copy)
 
     byteBuffer = byteBuffer.slice()
+    position = 0
     debug("Extract result " + copyBuf.utf8str)
     copyBuf
   }

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/streaming/ByteBufferUtilsTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/streaming/ByteBufferUtilsTest.scala
@@ -10,7 +10,7 @@ class ByteBufferUtilsTest extends Test {
   test("ByteBufferUtils.append") {
     val input = Buf.ByteBuffer.Shared.extract(Buf.Utf8("1"))
     input.get()
-    val byteBufferResult = ByteBufferUtils.append(input, Buf.Utf8(",2"))
+    val byteBufferResult = ByteBufferUtils.append(input, Buf.Utf8(",2"),0)
 
     byteBufferResult.utf8str should equal("1,2")
   }


### PR DESCRIPTION
Problem

When a Json Object is split over two bufs the parsing fails. I added some extra tests to StreamingTest. 

Solution

In the JsonArrayChunker when appending the buf use  do not reset the position. Only reset position on slice. 
