### PR TITLE
finatra - Attempt to parallelize TravisCI build to decrease run time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,40 @@ sudo: false
 language: scala
 
 env:
-  - JAVA_OPTS="-DSKIP_FLAKY=true -Dsbt.log.noformat=true"
+  global:
+    - JAVA_OPTS="-DSKIP_FLAKY=true -Dsbt.log.noformat=true"
+
+  matrix:
+    - PROJECT=benchmarks
+    - PROJECT=http
+    - PROJECT=httpclient
+    - PROJECT=injectApp
+    - PROJECT=injectCore
+    - PROJECT=injectLogback
+    - PROJECT=injectModules
+    - PROJECT=injectRequestScope
+    - PROJECT=injectServer
+    - PROJECT=injectSlf4j
+    - PROJECT=injectThrift
+    - PROJECT=injectThriftClient
+    - PROJECT=injectThriftClientHttpMapper
+    - PROJECT=injectUtils
+    - PROJECT=jackson
+    - PROJECT=thrift
+    - PROJECT=utils
+    # examples
+    - PROJECT=benchmarkServer
+    - PROJECT=exampleHttpJavaServer
+    - PROJECT=exampleInjectJavaServer
+    - PROJECT=exampleTwitterServer
+    - PROJECT=exampleWebDashboard
+    - PROJECT=helloWorld
+    - PROJECT=streamingExample
+    - PROJECT=thriftExampleIdl
+    - PROJECT=thriftExampleServer
+    - PROJECT=thriftJavaExampleIdl
+    - PROJECT=thriftJavaExampleServer
+    - PROJECT=twitterClone
 
 # These directories are cached to S3 at the end of the build
 cache:
@@ -36,8 +69,9 @@ before_script:
   - travis_retry ./sbt --error ++$TRAVIS_SCALA_VERSION update
 
 script:
-  - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
-  - ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+  # run for all environments
+  - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverage "$PROJECT/test" coverageReport
 
 after_success:
+  - ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Problem

The current TravisCI build is taking too long as caching of directories
appears to be broken (or now only caching upon successful builds).

However, we rely on the caching to kick in to eventually allow the
build to successfully complete.

Solution

We've tried a few times to parallelize the build in the same manner
as the Finagle TravisCI but previous attempts have failed. I'm hopeful
this one will work and we'll have a successful build.

I've updated the `.travis.yml` config to break out each Finatra project
into a matrix.

Result

Ideally, a successful build. Starting with the build for this PR.
