### PR TITLE
http: Remove need for manual 'apply' on injected filter context

### DIFF
--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
@@ -104,6 +104,14 @@ class DoEverythingController @Inject()(
     }
   }
 
+  filter[ForbiddenFilter] {
+    prefix("/1.1") {
+      get("/forbiddenByFilterPrefilter-nested") { request: Request =>
+        "ok!"
+      }
+    }
+  }
+
   get("/forwarded") { request: Request =>
     forward(request, "/forwarded/get")
   }

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -166,6 +166,13 @@ class DoEverythingServerFeatureTest extends FeatureTest with Mockito {
     )
   }
 
+  test("/forbiddenByFilter (nested prefixed outer)") {
+    server.httpGet(
+      "/1.1/forbiddenByFilterPrefilter-nested",
+      andExpect = Forbidden
+    )
+  }
+
   test("/appendMultiplePrefixed (prefixed)") {
     server.httpGet(
       "/1.1/appendMultiplePrefixed",


### PR DESCRIPTION
Problem

When using injected filters + nested bodies in the route DSL, one was
required to manually call 'apply' due to the compiler confusing the
overloaded 'filter' methods.

The following code does not work
```
filter[MyFilter] {
  // route def
}
```
however, we're able to do
```
filter(new MyFilter) {
  // route def
}
```

In order to use the former, one would have to do:
```
filter[MyFilter].apply {

}
```

Solution

In order to fix this, another overload for the injected filter DSL type
is added. This allows for more fluent filter definition by allowing the
syntax showed in the first example above, mirroring the capabilities of
non-injected filter syntax and prefix syntax.

---
**Note**: The issue here was actually a side-effect from the implementation I did for filter DSL improvements here: #393, so i wanted to make sure to fix up the thing I overlooked! 😆 