### PR TITLE
added @Pattern annotation to finatra/jackson for regex based string v…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Unreleased
 Added
 ~~~~~
 
+*  finatra-jackson: Added @Pattern annotation to support to finatra/jackson for regex pattern validation on string values
+
 * inject-server: Add lint rule to alert when deprecated `util-logging` JUL flags from the
   `c.t.inject.server.DeprecatedLogging` trait are user defined. This trait was mixed-in
   only for backwards compatibility when TwitterServer was moved to the slf4j-api and the flags are

--- a/jackson/src/main/java/com/twitter/finatra/json/internal/caseclass/validation/validators/PatternInternal.java
+++ b/jackson/src/main/java/com/twitter/finatra/json/internal/caseclass/validation/validators/PatternInternal.java
@@ -1,0 +1,20 @@
+package com.twitter.finatra.json.internal.caseclass.validation.validators;
+
+import com.twitter.finatra.validation.Validation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({PARAMETER})
+@Retention(RUNTIME)
+@Validation(validatedBy = PatternValidator.class)
+public @interface PatternInternal {
+
+    /**
+     * @return the regular expression to match
+     */
+    String regexp();
+}

--- a/jackson/src/main/resources/com/twitter/finatra/json/validation.properties
+++ b/jackson/src/main/resources/com/twitter/finatra/json/validation.properties
@@ -9,3 +9,4 @@ com.twitter.finatra.json.internal.caseclass.validation.validators.RangeInternal 
 com.twitter.finatra.json.internal.caseclass.validation.validators.SizeInternal              = size [%s] is not between %s and %s
 com.twitter.finatra.json.internal.caseclass.validation.validators.TimeGranularityInternal   = [%s] is not %s granularity
 com.twitter.finatra.json.internal.caseclass.validation.validators.UUIDInternal              = [%s] is not a valid UUID
+com.twitter.finatra.json.internal.caseclass.validation.validators.Pattern                   = [%s] is no match with regex %s

--- a/jackson/src/main/resources/com/twitter/json/validation.properties
+++ b/jackson/src/main/resources/com/twitter/json/validation.properties
@@ -9,3 +9,5 @@ com.twitter.finatra.json.internal.caseclass.validation.validators.RangeInternal 
 com.twitter.finatra.json.internal.caseclass.validation.validators.SizeInternal              = size [%s] is not between %s and %s
 com.twitter.finatra.json.internal.caseclass.validation.validators.TimeGranularityInternal   = [%s] is not %s granularity
 com.twitter.finatra.json.internal.caseclass.validation.validators.UUIDInternal              = [%s] is not a valid UUID
+com.twitter.finatra.json.internal.caseclass.validation.validators.Pattern                   = [%s] is no match with regex %s
+

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/validation/validators/PatternValidator.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/validation/validators/PatternValidator.scala
@@ -1,0 +1,73 @@
+package com.twitter.finatra.json.internal.caseclass.validation.validators
+
+import com.twitter.finatra.json.internal.caseclass.validation.validators.PatternValidator._
+import com.twitter.finatra.validation._
+
+private[finatra] object PatternValidator {
+  def errorMessage(resolver: ValidationMessageResolver, value: Any, regex: String): String = {
+    resolver.resolve(classOf[Pattern], value, regex)
+  }
+
+  def errorMessage(resolver: ValidationMessageResolver): String = {
+    resolver.resolve(classOf[Pattern])
+  }
+}
+
+private[finatra] class PatternValidator(validationMessageResolver: ValidationMessageResolver,
+                                        annotation: Pattern)
+  extends Validator[Pattern, Any](validationMessageResolver, annotation) {
+
+  private val regexp: String = annotation.regexp()
+
+  override def isValid(value: Any): ValidationResult = {
+    value match {
+      case arrayValue: Array[_] =>
+        validationResult(arrayValue)
+      case traversableValue: Traversable[_] =>
+        validationResult(traversableValue)
+      case stringValue: String =>
+        validationResult(stringValue)
+      case _ =>
+        throw new IllegalArgumentException(s"Class [${value.getClass}}] is not supported by ${this.getClass}")
+    }
+  }
+
+  private def validationResult(value: Traversable[_]): ValidationResult = {
+    if (regexp.isEmpty) {
+      return ValidationResult.Invalid(errorMessage(validationMessageResolver), ErrorCode.PatternCannotBeEmpty)
+    }
+    if (value.forall(x => validate(x.toString))) {
+      ValidationResult.Valid
+    } else {
+      ValidationResult.validate(
+        condition = false,
+        errorMessage(validationMessageResolver, value, regexp),
+        errorCode("[]", regexp)
+      )
+    }
+  }
+
+  private def validationResult(value: String): ValidationResult = {
+    if (regexp.isEmpty) {
+      return ValidationResult.Invalid(errorMessage(validationMessageResolver), ErrorCode.PatternCannotBeEmpty)
+    }
+    ValidationResult.validate(
+      validate(value),
+      errorMessage(validationMessageResolver, value, regexp),
+      errorCode(value, regexp)
+    )
+  }
+
+  private def validate(value: String): Boolean = {
+    val regex = regexp.r
+    regex.findFirstIn(value) match {
+      case None => false
+      case _ => true
+
+    }
+  }
+
+  private def errorCode(value: String, regex: String) = {
+    ErrorCode.PatternNotMatched(value, regex)
+  }
+}

--- a/jackson/src/main/scala/com/twitter/finatra/validation/ErrorCode.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/validation/ErrorCode.scala
@@ -25,4 +25,6 @@ object ErrorCode {
   case class ValueOutOfRange(value: Number, min: Long, max: Long) extends ErrorCode
   case class ValueTooLarge(maxValue: Long, value: Number) extends ErrorCode
   case class ValueTooSmall(minValue: Long, value: Number) extends ErrorCode
+  case class PatternNotMatched(value: String, regex: String) extends ErrorCode
+  case object PatternCannotBeEmpty extends ErrorCode
 }

--- a/jackson/src/main/scala/com/twitter/finatra/validation/package.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/validation/package.scala
@@ -21,4 +21,5 @@ package object validation {
   type TimeGranularity =
     com.twitter.finatra.json.internal.caseclass.validation.validators.TimeGranularityInternal @param
   type UUID = com.twitter.finatra.json.internal.caseclass.validation.validators.UUIDInternal @param
+  type Pattern = com.twitter.finatra.json.internal.caseclass.validation.validators.PatternInternal @param
 }

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclass/validation/validators/PatternValidatorTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclass/validation/validators/PatternValidatorTest.scala
@@ -1,0 +1,60 @@
+package com.twitter.finatra.json.tests.internal.caseclass.validation.validators
+
+import com.twitter.finatra.json.internal.caseclass.validation.validators.PatternValidator
+import com.twitter.finatra.validation.ValidationResult.{Invalid, Valid}
+import com.twitter.finatra.validation.{ErrorCode, Pattern, ValidationResult, ValidatorTest}
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+case class NumberPatternExample(@Pattern(regexp = "[0-9]+") stringValue: String)
+
+case class NumberPatternArrayExample(@Pattern(regexp = "[0-9]+") stringValue: Array[String])
+
+case class EmptyPatternExample(@Pattern(regexp = "") stringValue: String)
+
+
+class PatternValidatorTest extends ValidatorTest with GeneratorDrivenPropertyChecks {
+
+  test("pass validation when regex matches for array type") {
+    val passValue = for {
+      size <- Gen.choose(10, 50)
+    } yield Array.fill(size) {
+      Gen.choose(10, 100)
+    }
+    forAll(passValue) {
+      value => validate[NumberPatternArrayExample](value) should equal(Valid)
+    }
+  }
+
+  test("pass validation when regex matches") {
+    validate[NumberPatternExample]("12345") should equal(Valid)
+
+  }
+
+  test("fail validation when regex not matches") {
+    validate[NumberPatternExample]("meros") should equal(Invalid(errorMessage("meros", "[0-9]+"), ErrorCode.PatternNotMatched("meros", "[0-9]+")))
+  }
+
+  test("fail validation when regex not matches for some items in array") {
+    val failValue = for {
+      size <- Gen.choose(1, 5)
+    } yield Array.fill(size) {
+      "invalid"
+    }
+    forAll(failValue) {
+      value => validate[NumberPatternArrayExample](value) should equal(Invalid(errorMessage(value.toString, "[0-9]+"), ErrorCode.PatternNotMatched("[]", "[0-9]+")))
+    }
+  }
+
+  test("fail validation when given regex empty") {
+    validate[EmptyPatternExample]("1234") should equal(Invalid(PatternValidator.errorMessage(messageResolver), ErrorCode.PatternCannotBeEmpty))
+  }
+
+  private def validate[C: Manifest](value: Any): ValidationResult = {
+    super.validate(manifest[C].runtimeClass, "stringValue", classOf[Pattern], value)
+  }
+
+  private def errorMessage(value: String, regex: String): String = {
+    PatternValidator.errorMessage(messageResolver, value, regex)
+  }
+}


### PR DESCRIPTION
finatra-jackson: added `@Pattern` annotation for regex based string validation

Problem

We should able to validate http request parameters whether match the given regex pattern.
For instance, Finatra should able to validate phone parameter whether matches to phone pattern.

`case class MyRequest(phone: String)`

Solution

Added `@Pattern `annotation to finatra-jackson for regex based validation. If the regex do not match, it will return PatternNotMatches errorCode which contains the regex and value

Result
With `@Pattern` annotation we provide regex that checks the parameter match or not.

`case class MyRequest( @Pattern(regexp= "^[+][(]{0,1}[0-9]{1,4}[)]{0,1}[-\s./0-9]$") phone: String)`