### PR TITLE
Upgrade to Scala 2.12.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_cache:
 
 scala:
   - 2.11.12
-  - 2.12.7
+  - 2.12.8
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ val releaseVersion = "19.4.0-SNAPSHOT"
 
 lazy val buildSettings = Seq(
   version := releaseVersion,
-  scalaVersion := "2.12.7",
-  crossScalaVersions := Seq("2.11.12", "2.12.7"),
+  scalaVersion := "2.12.8",
+  crossScalaVersions := Seq("2.11.12", "2.12.8"),
   scalaModuleInfo := scalaModuleInfo.value.map(_.withOverrideScalaVersion(true)),
   fork in Test := true,
   javaOptions in Test ++= travisTestJavaOptions


### PR DESCRIPTION
Problem

- Upgrade to the latest Scala 2.12.8

Solution

- Just update build.sbt

Result

Scala 2.12.8 has several bug fixes for Scala 2.12.7: 
https://github.com/scala/scala/releases/tag/v2.12.8

Using the latest stable version is always preferred unless there is a reason for not doing so.
