### PR TITLE
Upgrade to sbt 1.2.8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.2.8

--- a/sbt
+++ b/sbt
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sbtver=1.1.4
+sbtver=1.2.8
 sbtjar=sbt-launch.jar
 sbtsha128=ac6b13b709e3c0e3a8b2b3bf3031ec57660cb813
 

--- a/sbt
+++ b/sbt
@@ -2,7 +2,7 @@
 
 sbtver=1.2.8
 sbtjar=sbt-launch.jar
-sbtsha128=ac6b13b709e3c0e3a8b2b3bf3031ec57660cb813
+sbtsha128=073c169c6e1a47b8ae78a7a718b907424dedab30
 
 sbtrepo="https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch"
 


### PR DESCRIPTION
Problem

sbt-1.1.x series have many bugs (including class loader bugs, etc.). Using the latest version is preferred to avoid hitting its bugs. 
https://www.scala-sbt.org/1.0/docs/sbt-1.1-Release-Notes.html

Solution

- Upgraded to sbt 1.2.8

Result

- I believe sbt-1.2.x series has no backward incompatible changes to sbt-1.1.x, so we can keep using the same sbt plugins.
