### PR TITLE
Fix project references in Readme.md

### DIFF
--- a/examples/http-server/README.md
+++ b/examples/http-server/README.md
@@ -17,12 +17,12 @@ Running
 -------
 ```
 [finatra] $ cd ../../
-[finatra] $ ./sbt "project helloWorld" "run -http.port=:8888 -admin.port=:9990"
+[finatra] $ ./sbt "project exampleHttpServer" "run -http.port=:8888 -admin.port=:9990"
 ```
 * Then browse to: [http://localhost:8888/hi?name=foo](http://localhost:8888/hi?name=foo)
 * Or view the [twitter-server admin interface](https://twitter.github.io/twitter-server/Features.html#admin-http-interface): [http://localhost:9990/admin](http://localhost:9990/admin)
 * Or build and run a deployable jar:
 ```
-[finatra] $ ./sbt helloWorld/assembly
-[finatra] $ java -jar examples/hello-world/target/scala-2.XX/hello-world-assembly-X.XX.X.jar -http.port=:8888 -admin.port=:9990
+[finatra] $ ./sbt exampleHttpServer/assembly
+[finatra] $ java -jar examples/exampleHttpServer/target/scala-2.XX/hello-world-assembly-X.XX.X.jar -http.port=:8888 -admin.port=:9990
 ```


### PR DESCRIPTION
Fix project name reference in Readme.md to adapt to new new in build.sbt

Problem

When running command to build or run project describe in Readme project reference `helloWorld` is outdated and does not corresponds to the on in build.sbt.

Solution

Change project reference from `helloWorld` to `exampleHttpServer`

