### PR TITLE
Change spelling of the word Sever to Server

### DIFF
--- a/doc/src/sphinx/user-guide/getting-started/modules.rst
+++ b/doc/src/sphinx/user-guide/getting-started/modules.rst
@@ -150,7 +150,7 @@ For example:
 The argument `foo: Foo` will be "injected" in the sense that the injector will attempt to provide
 an instance of `foo` when invoking the method.
 
-See `Module Configuration in Severs <#module-configuration-in-servers>`__.
+See `Module Configuration in Servers <#module-configuration-in-servers>`__.
 
 Using Flags in Modules
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Problem

There was a spelling error in which the word server was spelled incorrectly

Solution

Update the text to spell the word server correctly
