### PR TITLE
finatra-http Issue#520 - PrefixedDSL support empty route

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Added
  * finatra: Add NullKafkaProducer for unit tests to avoid network connection failures in the log
    ``PHAB_ID=D429004``.
 
+Changed
+~~~~~~~
+ * finatra-http: RouteDSL/PrefixedDSL no longer require route when a valid prefix is provided
+
 20.1.0
 ------
 

--- a/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
@@ -568,12 +568,12 @@ private[http] trait RouteDSL extends RouteState { self =>
     index: Option[RouteIndex],
     callback: RequestType => ResponseType
   ) = {
-    val prefixedRoute = prefixRoute(route)
-    require(
-      prefixedRoute.startsWith("/"),
-      s"""Invalid route: "$route." Routes MUST begin with a forward slash (/).""")
-
     contextWrapper {
+      val prefixedRoute = prefixRoute(route)
+      require(
+        prefixedRoute.startsWith("/"),
+        s"""Invalid route: "$route." Routes MUST begin with a forward slash (/).""")
+
       routeBuilders += new RouteBuilder(
         method,
         prefixedRoute,

--- a/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
@@ -124,7 +124,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* GET/ */
 
   def get[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -171,7 +171,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* POST/ */
 
   def post[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -218,7 +218,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* PUT/ */
 
   def put[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -265,7 +265,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* HEAD/ */
 
   def head[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -312,7 +312,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* PATCH/ */
 
   def patch[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -359,7 +359,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* DELETE/ */
 
   def delete[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -406,7 +406,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* TRACE/ */
 
   def trace[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -453,7 +453,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* OPTIONS/ */
 
   def options[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -500,7 +500,7 @@ private[http] trait RouteDSL extends RouteState { self =>
   /* ANY/ */
 
   def any[RequestType: TypeTag, ResponseType: TypeTag](
-    route: String,
+    route: String = "",
     name: String = "",
     admin: Boolean = false,
     index: Option[RouteIndex] = None
@@ -568,14 +568,15 @@ private[http] trait RouteDSL extends RouteState { self =>
     index: Option[RouteIndex],
     callback: RequestType => ResponseType
   ) = {
+    val prefixedRoute = prefixRoute(route)
     require(
-      route.startsWith("/"),
+      prefixedRoute.startsWith("/"),
       s"""Invalid route: "$route." Routes MUST begin with a forward slash (/).""")
 
     contextWrapper {
       routeBuilders += new RouteBuilder(
         method,
-        prefixRoute(route),
+        prefixedRoute,
         name,
         clazz,
         admin,
@@ -589,7 +590,7 @@ private[http] trait RouteDSL extends RouteState { self =>
 
   private def prefixRoute(route: String): String = {
     /* routes and prefixes MUST begin with a leading / */
-    contextVar().prefix match {
+    context.prefix match {
       case prefix if prefix.nonEmpty => s"$prefix$route"
       case _ => route
     }

--- a/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/RouteDSL.scala
@@ -590,7 +590,7 @@ private[http] trait RouteDSL extends RouteState { self =>
 
   private def prefixRoute(route: String): String = {
     /* routes and prefixes MUST begin with a leading / */
-    context.prefix match {
+    contextVar().prefix match {
       case prefix if prefix.nonEmpty => s"$prefix$route"
       case _ => route
     }

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/controllers/DoEverythingController.scala
@@ -100,6 +100,12 @@ class DoEverythingController @Inject()(
     }
   }
 
+  prefix("/1.2/users") {
+    get() { _: Request =>
+      "ok!"
+    }
+  }
+
   filter[ForbiddenFilter].prefix("/1.1") {
     get("/forbiddenByFilterPrefilter") { _: Request =>
       "ok!"

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -189,6 +189,14 @@ class DoEverythingServerFeatureTest extends FeatureTest with Mockito {
     )
   }
 
+  test("/1.2/users (empty route)") {
+    server.httpGet(
+      "/1.2/users",
+      andExpect = Ok,
+      withBody = "ok!"
+    )
+  }
+
   test("GET /bytearray") {
     val response = server.httpGet("/bytearray")
 

--- a/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTest.scala
@@ -133,4 +133,32 @@ class RouteDSLTest extends Test {
 
     response.headerMap("response") shouldEqual "true"
   }
+
+  test("PrefixedDSL should work with valid prefix and empty route") {
+    new PrefixedDSL("/foo") {
+      get() { _: Request =>"bar" }
+
+      post() { _: Request => "bar" }
+
+      put() { _: Request => "bar" }
+
+      head() { _: Request => "bar" }
+
+      patch() { _: Request => "bar" }
+
+      delete() { _: Request => "bar" }
+
+      trace() { _: Request => "bar" }
+
+      options() { _: Request => "bar" }
+    }
+  }
+
+  test("RouteDSL should fail with empty route and no prefix") {
+    intercept[IllegalArgumentException] {
+      new RouteDSL {
+        get() { _: Request => "bar" }
+      }
+    }
+  }
 }

--- a/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTest.scala
@@ -135,24 +135,22 @@ class RouteDSLTest extends Test {
   }
 
   test("PrefixedDSL should work with valid prefix and empty route") {
-    new RouteDSL {
-      prefix("/foo") {
-        get() { _: Request =>"bar" }
+    new PrefixedDSL("/foo") {
+      get() { _: Request =>"bar" }
 
-        post() { _: Request => "bar" }
+      post() { _: Request => "bar" }
 
-        put() { _: Request => "bar" }
+      put() { _: Request => "bar" }
 
-        head() { _: Request => "bar" }
+      head() { _: Request => "bar" }
 
-        patch() { _: Request => "bar" }
+      patch() { _: Request => "bar" }
 
-        delete() { _: Request => "bar" }
+      delete() { _: Request => "bar" }
 
-        trace() { _: Request => "bar" }
+      trace() { _: Request => "bar" }
 
-        options() { _: Request => "bar" }
-      }
+      options() { _: Request => "bar" }
     }
   }
 

--- a/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/routing/RouteDSLTest.scala
@@ -135,22 +135,24 @@ class RouteDSLTest extends Test {
   }
 
   test("PrefixedDSL should work with valid prefix and empty route") {
-    new PrefixedDSL("/foo") {
-      get() { _: Request =>"bar" }
+    new RouteDSL {
+      prefix("/foo") {
+        get() { _: Request =>"bar" }
 
-      post() { _: Request => "bar" }
+        post() { _: Request => "bar" }
 
-      put() { _: Request => "bar" }
+        put() { _: Request => "bar" }
 
-      head() { _: Request => "bar" }
+        head() { _: Request => "bar" }
 
-      patch() { _: Request => "bar" }
+        patch() { _: Request => "bar" }
 
-      delete() { _: Request => "bar" }
+        delete() { _: Request => "bar" }
 
-      trace() { _: Request => "bar" }
+        trace() { _: Request => "bar" }
 
-      options() { _: Request => "bar" }
+        options() { _: Request => "bar" }
+      }
     }
   }
 


### PR DESCRIPTION
Problem
Route is currently always required, even when a prefix is supplied and no additional route is desirable.

Solution
Default routes to an empty String and alter the existing validation. Prefix is now applied before validation.

