### PR TITLE
root: Upgrade test library versions in preparation for 2.13 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,6 @@ lazy val versions = new {
   val jodaConvert = "1.5"
   val jodaTime = "2.10.2"
   val json4s = "3.6.7"
-  val junit = "4.12"
   val kafka = "2.2.0"
   val libThrift = "0.10.0"
   val logback = "1.2.3"
@@ -108,12 +107,13 @@ lazy val versions = new {
   val mustache = "0.8.18"
   val nscalaTime = "2.14.0"
   val rocksdbjni = "5.14.2"
-  val scalaCheck = "1.14.0"
+  val scalaCheck = "1.14.3"
   val scalaGuice = "4.2.0"
-  val scalaTest = "3.0.8"
+  val scalaTest = "3.1.1"
+  val scalaTestPlusScalacheck = "3.1.0.0-RC2"
   val slf4j = "1.7.30"
   val snakeyaml = "1.24"
-  val specs2 = "2.4.17"
+  val specs2 = "4.9.2"
   val javaxBind = "2.3.0"
   val javaxActivation = "1.1.1"
 }
@@ -137,6 +137,7 @@ lazy val baseSettings = Seq(
     "org.mockito" % "mockito-core" %  versions.mockito % Test,
     "org.scalacheck" %% "scalacheck" % versions.scalaCheck % Test,
     "org.scalatest" %% "scalatest" %  versions.scalaTest % Test,
+    "org.scalatestplus" %% "scalacheck-1-14" %  versions.scalaTestPlusScalacheck % Test,
     "org.specs2" %% "specs2-core" % versions.specs2 % Test,
     "org.specs2" %% "specs2-junit" % versions.specs2 % Test,
     "org.specs2" %% "specs2-mock" % versions.specs2 % Test

--- a/inject/inject-core/src/test/scala/com/twitter/inject/Mockito.scala
+++ b/inject/inject-core/src/test/scala/com/twitter/inject/Mockito.scala
@@ -1,6 +1,6 @@
 package com.twitter.inject
 
-import org.mockito.Matchers
+import org.mockito.ArgumentMatchers
 import org.specs2.matcher.ScalaTestExpectations
 
 /**
@@ -13,7 +13,7 @@ import org.specs2.matcher.ScalaTestExpectations
 trait Mockito extends org.specs2.mock.Mockito with ScalaTestExpectations with Logging {
 
   protected def meq[T](obj: T): T = {
-    Matchers.eq(obj)
+    ArgumentMatchers.eq(obj)
   }
 
   protected def eqManifest[T: Manifest]: Manifest[T] = {

--- a/inject/inject-core/src/test/scala/com/twitter/inject/Test.scala
+++ b/inject/inject-core/src/test/scala/com/twitter/inject/Test.scala
@@ -1,8 +1,6 @@
 package com.twitter.inject
 
-import org.junit.runner.RunWith
-import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.funsuite.AnyFunSuite
 
 /**
  * Extensible abstract test class which extends [[org.scalatest.FunSuite]] and
@@ -21,10 +19,9 @@ import org.scalatest.junit.JUnitRunner
  *   }
  * }}}
  *
- * @see [[org.scalatest.FunSuite FunSuite]]
+ * @see [[org.scalatest.funsuite.AnyFunSuite FunSuite]]
  * @see [[com.twitter.inject.TestMixin Finatra TestMixin]]
  */
-@RunWith(classOf[JUnitRunner])
 abstract class Test
-  extends FunSuite
+  extends AnyFunSuite
   with TestMixin

--- a/kafka-streams/kafka-streams/src/test/scala/com/twitter/finatra/kafkastreams/transformer/FinatraTransformerTest.scala
+++ b/kafka-streams/kafka-streams/src/test/scala/com/twitter/finatra/kafkastreams/transformer/FinatraTransformerTest.scala
@@ -16,7 +16,7 @@ import org.apache.kafka.streams.processor.internals.{ProcessorNode, RecordCollec
 import org.apache.kafka.streams.state.internals.{FinatraStores, WrappedStateStore}
 import org.apache.kafka.test.{InternalMockProcessorContext, MockProcessorNode, NoOpRecordCollector, TestUtils}
 import org.hamcrest.{BaseMatcher, Description}
-import org.mockito.{Matchers, Mockito}
+import org.mockito.{ArgumentMatcher, ArgumentMatchers, Mockito}
 
 class FinatraTransformerTest extends Test with com.twitter.inject.Mockito {
   val firstMessageTimestamp = 100000
@@ -102,15 +102,15 @@ class FinatraTransformerTest extends Test with com.twitter.inject.Mockito {
   }
 
   private def matchTo(expectedTimestamp: Int): To = {
-    Matchers.argThat(new BaseMatcher[To] {
-      override def matches(to: scala.Any): Boolean = {
+    ArgumentMatchers.argThat(new ArgumentMatcher[To] {
+      override def matches(to: To): Boolean = {
         val toInternal = new ToInternal
-        toInternal.update(to.asInstanceOf[To])
+        toInternal.update(to)
         toInternal.timestamp() == expectedTimestamp
       }
 
-      override def describeTo(description: Description): Unit = {
-        description.appendText(s"To(timestamp = $expectedTimestamp)")
+      override def toString: String = {
+        s"To(timestamp = $expectedTimestamp)"
       }
     })
   }


### PR DESCRIPTION
Problem

Several libraries used for testing were using older versions that were
not cross-compiled for Scala 2.13.

Solution

Upgrade the relevant libraries to latest versions supporting Scala 2.13
and add new libraries necessary due to deprecations in the existing
libraries.

Result

Base testing libraries are now compatiable with a Scala 2.13 cross
builder. Building for Scala 2.12 and 2.11 still works as expected.