### PR TITLE
inject-slf4j: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -618,7 +618,7 @@ lazy val injectMdc = (project in file("inject/inject-mdc"))
   )
 
 lazy val injectSlf4j = (project in file("inject/inject-slf4j"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-slf4j",
     moduleName := "inject-slf4j",


### PR DESCRIPTION
Depends on #528

Problem

inject-slf4j is not cross-built for Scala 2.13.

Solution

Update inject-slf4j module to cross-build for Scala 2.13 using new SBT
settings.

Result

inject-slf4j is cross-built for Scala 2.13.
