### PR TITLE
inject-core: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val versions = new {
   val logback = "1.2.3"
   val mockitoScala = "1.14.8"
   val mustache = "0.8.18"
-  val nscalaTime = "2.14.0"
+  val nscalaTime = "2.22.0"
   val rocksdbjni = "5.14.2"
   val scalaCheck = "1.14.3"
   val scalaGuice = "4.2.11"
@@ -117,7 +117,7 @@ lazy val versions = new {
 lazy val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
 
 lazy val withTwoThirteen = Seq(
-  crossScalaVersions += "2.13.1",
+  crossScalaVersions += "2.13.3",
   libraryDependencies += scalaCollectionCompat,
   scalacOptions := {
     val previous = scalacOptions.value
@@ -378,7 +378,7 @@ lazy val injectCoreTestJarSources =
     "com/twitter/inject/WhenReadyMixin"
   )
 lazy val injectCore = (project in file("inject/inject-core"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-core",
     moduleName := "inject-core",

--- a/build.sbt
+++ b/build.sbt
@@ -618,7 +618,7 @@ lazy val injectMdc = (project in file("inject/inject-mdc"))
   )
 
 lazy val injectSlf4j = (project in file("inject/inject-slf4j"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-slf4j",
     moduleName := "inject-slf4j",


### PR DESCRIPTION
Depends on #529

Problem

inject-core is not cross-built for Scala 2.13.

Solution

Update inject-core module to cross-build for Scala 2.13 using new SBT
settings. Adds in shim for old code no longer supported by Scalaguice to generate TypeLiterals from Manifests; it was simpler to do this than change the context bound everywhere (which led to a host of other compatibility issues). 

Result

inject-core is cross-built for Scala 2.13.