### PR TITLE
inject-utils: Cross-build for 2.13 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -692,7 +692,7 @@ lazy val injectThriftClient = (project in file("inject/inject-thrift-client"))
   )
 
 lazy val injectUtils = (project in file("inject/inject-utils"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-utils",
     moduleName := "inject-utils",

--- a/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/iterable.scala
+++ b/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/iterable.scala
@@ -1,6 +1,6 @@
 package com.twitter.inject.conversions
 
-import scala.collection.generic.CanBuildFrom
+import scala.collection.compat.BuildFrom
 import scala.collection.mutable.{HashSet => MutableHashSet}
 import scala.language.higherKinds
 
@@ -16,10 +16,8 @@ object iterable {
      */
     def distinctBy[HashCodeType](
       hash: Elem => HashCodeType
-    )(
-      implicit cbf: CanBuildFrom[From[Elem], Elem, From[Elem]]
-    ): From[Elem] = {
-      val builder = cbf()
+    )(implicit cbf: BuildFrom[From[Elem], Elem, From[Elem]]): From[Elem] = {
+      val builder = cbf.newBuilder(self)
       val seen = MutableHashSet[HashCodeType]()
 
       for (elem <- self) {

--- a/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/option.scala
+++ b/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/option.scala
@@ -72,7 +72,7 @@ object option {
   implicit class RichOptionMap[A, B](val self: Option[Map[A, B]]) extends AnyVal {
     def mapInnerValues[C](func: B => C): Option[Map[A, C]] = {
       for (map <- self) yield {
-        map.mapValues(func)
+        map.map { case (k, v) => k -> func(v) }
       }
     }
   }

--- a/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/seq.scala
+++ b/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/seq.scala
@@ -1,24 +1,21 @@
 package com.twitter.inject.conversions
 
 import scala.annotation.tailrec
-import scala.collection.breakOut
 
 object seq {
 
   implicit class RichSeq[A](val self: Seq[A]) extends AnyVal {
 
     def createMap[K, V](keys: A => K, values: A => V): Map[K, V] = {
-
-      self.map { elem =>
+      self.iterator.map { elem =>
         keys(elem) -> values(elem)
-      }(breakOut)
+      }.toMap
     }
 
     def createMap[K, V](values: A => V): Map[A, V] = {
-
       self.map { elem =>
         elem -> values(elem)
-      }(breakOut)
+      }.toMap
     }
 
     def foreachPartial(pf: PartialFunction[A, Unit]): Unit = {

--- a/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/tuple.scala
+++ b/inject/inject-utils/src/main/scala/com/twitter/inject/conversions/tuple.scala
@@ -41,8 +41,9 @@ object tuple {
     }
 
     def groupByKeyAndReduce(reduceFunc: (B, B) => B): Map[A, B] = {
-      groupByKey mapValues { values =>
-        values.reduce(reduceFunc)
+      groupByKey map {
+        case (k, values) =>
+          k -> values.reduce(reduceFunc)
       }
     }
 

--- a/inject/inject-utils/src/test/scala/com/twitter/inject/tests/utils/AnnotationUtilsTest.scala
+++ b/inject/inject-utils/src/test/scala/com/twitter/inject/tests/utils/AnnotationUtilsTest.scala
@@ -12,7 +12,7 @@ class AnnotationUtilsTest extends Test {
     val annotationMap: Map[String, Array[Annotation]] =
       AnnotationUtils.findAnnotations(classOf[CaseClassOneTwo], Array("one", "two"))
     annotationMap.isEmpty should be(false)
-    val annotations = annotationMap.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = annotationMap.flatMap { case (_, annotations) => annotations.toList }.toArray
 
     val found = AnnotationUtils.filterIfAnnotationPresent[MarkerAnnotation](annotations)
     found.length should be(1)
@@ -23,7 +23,7 @@ class AnnotationUtilsTest extends Test {
     val annotationMap: Map[String, Array[Annotation]] =
       AnnotationUtils.findAnnotations(classOf[CaseClassThreeFour], Array("three", "four"))
     annotationMap.isEmpty should be(false)
-    val annotations = annotationMap.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = annotationMap.flatMap { case (_, annotations) => annotations.toList }.toArray
     val filterSet: Set[Class[_ <: Annotation]] = Set(classOf[Annotation4])
     val found = AnnotationUtils.filterAnnotations(filterSet, annotations)
     found.length should be(1)
@@ -34,7 +34,7 @@ class AnnotationUtilsTest extends Test {
     val annotationMap: Map[String, Array[Annotation]] =
       AnnotationUtils.findAnnotations(classOf[CaseClassThreeFour], Array("three", "four"))
     annotationMap.isEmpty should be(false)
-    val annotations = annotationMap.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = annotationMap.flatMap { case (_, annotations) => annotations.toList }.toArray
     AnnotationUtils.findAnnotation(classOf[Annotation1], annotations) should be(None) // not found
     val found = AnnotationUtils.findAnnotation(classOf[Annotation3], annotations)
     found.isDefined should be(true)
@@ -47,7 +47,7 @@ class AnnotationUtilsTest extends Test {
         classOf[CaseClassOneTwoThreeFour],
         Array("one", "two", "three", "four"))
     annotationMap.isEmpty should be(false)
-    val annotations = annotationMap.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = annotationMap.flatMap { case (_, annotations) => annotations.toList }.toArray
     AnnotationUtils.findAnnotation[MarkerAnnotation](annotations) should be(None) // not found
     AnnotationUtils.findAnnotation[Annotation1](annotations).isDefined should be(true)
     AnnotationUtils.findAnnotation[Annotation2](annotations).isDefined should be(true)
@@ -61,7 +61,7 @@ class AnnotationUtilsTest extends Test {
         classOf[CaseClassOneTwoThreeFour],
         Array("one", "two", "three", "four"))
     annotationMap.isEmpty should be(false)
-    val annotations = annotationMap.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = annotationMap.flatMap { case (_, annotations) => annotations.toList }.toArray
     val found = AnnotationUtils.findAnnotation[Annotation1](annotations)
     found.isDefined should be(true)
 
@@ -75,7 +75,7 @@ class AnnotationUtilsTest extends Test {
         classOf[CaseClassOneTwoThreeFour],
         Array("one", "two", "three", "four"))
     annotationMap.isEmpty should be(false)
-    val annotations = annotationMap.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = annotationMap.flatMap { case (_, annotations) => annotations.toList }.toArray
     val annotation1 = AnnotationUtils.findAnnotation[Annotation1](annotations).get
     val annotation2 = AnnotationUtils.findAnnotation[Annotation2](annotations).get
     val annotation3 = AnnotationUtils.findAnnotation[Annotation3](annotations).get
@@ -91,29 +91,29 @@ class AnnotationUtilsTest extends Test {
     var found: Map[String, Array[Annotation]] =
       AnnotationUtils.findAnnotations(classOf[WithThings], Array("thing1", "thing2"))
     found.isEmpty should be(false)
-    var annotations = found.flatMap { case (_, annotations) => annotations }.toArray
+    var annotations = found.flatMap { case (_, annotations) => annotations.toList }.toArray
     annotations.length should equal(4)
 
     found = AnnotationUtils.findAnnotations(classOf[WithWidgets], Array("widget1", "widget2"))
     found.isEmpty should be(false)
-    annotations = found.flatMap { case (_, annotations) => annotations }.toArray
+    annotations = found.flatMap { case (_, annotations) => annotations.toList }.toArray
     annotations.length should equal(4)
 
     found = AnnotationUtils.findAnnotations(classOf[CaseClassOneTwo], Array("one", "two"))
     found.isEmpty should be(false)
-    annotations = found.flatMap { case (_, annotations) => annotations }.toArray
+    annotations = found.flatMap { case (_, annotations) => annotations.toList }.toArray
     annotations.length should equal(2)
 
     found = AnnotationUtils.findAnnotations(classOf[CaseClassThreeFour], Array("three", "four"))
     found.isEmpty should be(false)
-    annotations = found.flatMap { case (_, annotations) => annotations }.toArray
+    annotations = found.flatMap { case (_, annotations) => annotations.toList }.toArray
     annotations.length should equal(2)
 
     found = AnnotationUtils.findAnnotations(
       classOf[CaseClassOneTwoThreeFour],
       Array("one", "two", "three", "four"))
     found.isEmpty should be(false)
-    annotations = found.flatMap { case (_, annotations) => annotations }.toArray
+    annotations = found.flatMap { case (_, annotations) => annotations.toList }.toArray
     annotations.length should equal(4)
   }
 
@@ -121,7 +121,7 @@ class AnnotationUtilsTest extends Test {
     val found: Map[String, Array[Annotation]] =
       AnnotationUtils.findAnnotations(classOf[WithThings], Array("thing1", "thing2"))
     found.isEmpty should be(false)
-    val annotations = found.flatMap { case (_, annotations) => annotations }.toArray
+    val annotations = found.flatMap { case (_, annotations) => annotations.toList }.toArray
 
     val things = AnnotationUtils.filterAnnotations(Set(classOf[Thing]), annotations)
     things.foreach { thing =>


### PR DESCRIPTION
Depends on #530

Problem

injectUtils was not cross-built for Scala 2.13.

Solution

Add SBT setting to enable 2.13 cross-build for injectUtils

**NOTE** This has some of the first usages of the Scala collection compat library. https://github.com/twitter/finagle/issues/818 will probably be relevant here due to some of the changes. 

Result

injectUtils cross-built for Scala 2.13.