### PR TITLE
inject-ports: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -541,7 +541,7 @@ lazy val injectDtab = (project in file("inject/inject-dtab"))
   )
 
 lazy val injectPorts = (project in file("inject/inject-ports"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-ports",
     moduleName := "inject-ports",


### PR DESCRIPTION
Depends on #530

Problem

inject-ports is not cross-built for Scala 2.13.

Solution

Update inject-ports module to cross-build for Scala 2.13 using new SBT
settings.

Result

inject-ports is cross-built for Scala 2.13.