### PR TITLE
inject-app/inject-server: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -568,7 +568,7 @@ lazy val injectServerTestJarSources =
     "com/twitter/inject/server/package"
   )
 lazy val injectServer = (project in file("inject/inject-server"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-server",
     moduleName := "inject-server",

--- a/build.sbt
+++ b/build.sbt
@@ -489,7 +489,7 @@ lazy val injectAppTestJarSources =
     "com/twitter/inject/app/TestInjector"
   )
 lazy val injectApp = (project in file("inject/inject-app"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-app",
     moduleName := "inject-app",

--- a/inject/inject-app/src/main/scala/com/twitter/inject/app/App.scala
+++ b/inject/inject-app/src/main/scala/com/twitter/inject/app/App.scala
@@ -108,7 +108,7 @@ trait App extends com.twitter.app.App with Logging {
   private[this] lazy val appModules: Modules =
     new Modules(
       required =
-        frameworkModules ++ modules ++ javaModules.asScala, // user modules should replace framework
+        (frameworkModules ++ modules ++ javaModules.asScala).toSeq, // user modules should replace framework
       overrides =
         overrideModules ++ javaOverrideModules.asScala ++ frameworkOverrideModules // framework should replace user modules
     )

--- a/inject/inject-server/src/test/scala/com/twitter/inject/server/EmbeddedHttpClient.scala
+++ b/inject/inject-server/src/test/scala/com/twitter/inject/server/EmbeddedHttpClient.scala
@@ -151,7 +151,7 @@ private[twitter] class EmbeddedHttpClient private[twitter] (
     /* Pre - Execute */
 
     // Don't overwrite request.headers potentially in given request */
-    val defaults = _defaultHeaders().filterKeys(!request.headerMap.contains(_))
+    val defaults = _defaultHeaders().filter { case (key, _) => !request.headerMap.contains(key) }
     addOrRemoveHeaders(request, defaults)
     // headers added last so they can overwrite "defaults"
     addOrRemoveHeaders(request, headers)

--- a/inject/inject-server/src/test/scala/com/twitter/inject/server/EmbeddedTwitterServer.scala
+++ b/inject/inject-server/src/test/scala/com/twitter/inject/server/EmbeddedTwitterServer.scala
@@ -615,7 +615,7 @@ class EmbeddedTwitterServer(
   /** @throws IllegalStateException when a non [[InMemoryStatsReceiver]] is provided as a [[statsReceiverOverride]]. */
   @deprecated("Use the inMemoryStatsReceiverUtility#gaugeMap directly", "2019-05-17")
   def gaugeMap: SortedMap[String, () => Float] =
-    inMemoryStats.gauges.toSortedMap.mapValues(() => _)
+    inMemoryStats.gauges.toSortedMap.map { case (k, v) => k -> (() => v) }
 
   /**
    * Prints stats from the bound [[InMemoryStatsReceiver]] when applicable. If access to this method

--- a/inject/inject-server/src/test/scala/com/twitter/inject/server/InMemoryStatsReceiverUtility.scala
+++ b/inject/inject-server/src/test/scala/com/twitter/inject/server/InMemoryStatsReceiverUtility.scala
@@ -389,7 +389,7 @@ class InMemoryStatsReceiverUtility(inMemoryStatsReceiver: InMemoryStatsReceiver)
      *         value for the given name.
      */
     def toSortedMap: SortedMap[String, Float] =
-      inMemoryStatsReceiver.gauges.iterator.toMap.mapKeys(keyStr).mapValues(_.apply).toSortedMap
+      inMemoryStatsReceiver.gauges.iterator.toMap.mapKeys(keyStr).map { case (k, v) => k -> v.apply }.toSortedMap
 
     /**
      * A complete sorted `Set` of all [[com.twitter.finagle.stats.Gauge]] names collected by


### PR DESCRIPTION
Depends on #533 - last 2 commits only. 

Problem

inject-app and inject-server are not cross-built for Scala 2.13.

Solution

Update inject-app and inject-server modules to cross-build for Scala 2.13 using new SBT
settings.

Result

inject-app and inject-server are cross-built for Scala 2.13