### PR TITLE
utils/validation: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -746,7 +746,7 @@ lazy val benchmarks = project
 lazy val utilsTestJarSources =
   Seq("com/twitter/finatra/modules/", "com/twitter/finatra/test/")
 lazy val utils = project
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "finatra-utils",
     moduleName := "finatra-utils",
@@ -785,7 +785,7 @@ lazy val validationTestJarSources =
     "com/twitter/finatra/validation/ValidatorTest"
   )
 lazy val validation = project
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "finatra-validation",
     moduleName := "finatra-validation",

--- a/validation/src/main/scala/com/twitter/finatra/validation/Validator.scala
+++ b/validation/src/main/scala/com/twitter/finatra/validation/Validator.scala
@@ -3,12 +3,7 @@ package com.twitter.finatra.validation
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.twitter.finatra.utils.ClassUtils
 import com.twitter.finatra.validation.ValidationResult.{Invalid, Valid}
-import com.twitter.finatra.validation.internal.{
-  AnnotatedClass,
-  AnnotatedField,
-  AnnotatedMethod,
-  FieldValidator
-}
+import com.twitter.finatra.validation.internal.{AnnotatedClass, AnnotatedField, AnnotatedMethod, FieldValidator}
 import com.twitter.inject.conversions.map._
 import com.twitter.inject.utils.AnnotationUtils
 import com.twitter.util.Try
@@ -137,7 +132,7 @@ class Validator private[finatra] (cacheSize: Long, messageResolver: MessageResol
   private[finatra] def validateField[T](
     fieldValue: T,
     fieldValidators: Array[FieldValidator]
-  ): Seq[ValidationResult] = {
+  ): scala.collection.Seq[ValidationResult] = {
     if (fieldValidators.nonEmpty) {
       val results = new mutable.ArrayBuffer[ValidationResult](fieldValidators.length)
       var index = 0
@@ -165,7 +160,7 @@ class Validator private[finatra] (cacheSize: Long, messageResolver: MessageResol
   private[finatra] def validateMethods(
     obj: Any,
     methods: Array[AnnotatedMethod]
-  ): Seq[ValidationResult] = {
+  ): scala.collection.Seq[ValidationResult] = {
     if (methods.nonEmpty) {
       val results = new mutable.ArrayBuffer[ValidationResult](methods.length)
       var index = 0
@@ -183,7 +178,7 @@ class Validator private[finatra] (cacheSize: Long, messageResolver: MessageResol
   @deprecated(
     "The endpoint is not supposed to be use on its own, use validate(Any) instead",
     "2020-02-12")
-  def validateMethods(obj: Any): Seq[ValidationResult] = {
+  def validateMethods(obj: Any): scala.collection.Seq[ValidationResult] = {
     val methodValidations: Array[AnnotatedMethod] = getMethodValidations(obj.getClass)
     validateMethods(obj, methodValidations)
   }

--- a/validation/src/test/java/com/twitter/finatra/validation/tests/ValidatorJavaTest.java
+++ b/validation/src/test/java/com/twitter/finatra/validation/tests/ValidatorJavaTest.java
@@ -37,11 +37,19 @@ public class ValidatorJavaTest extends Assert {
   @Test
   public void testWithMessageResolver() {
     class CustomizedMessageResolver extends MessageResolver {
-      @Override
-      public String resolve(Class<? extends Annotation> clazz, Seq<Object> values) {
+      // 2.12 override
+      // @Override omitted to present both overloads as examples
+      public String resolve(Class<? extends Annotation> clazz, scala.collection.Seq<Object> values) {
+        return "Whatever you provided is wrong.";
+      }
+
+      // 2.13 override
+      // @Override omitted to present both overloads as examples
+      public String resolve(Class<? extends Annotation> clazz, scala.collection.immutable.Seq<Object> values) {
         return "Whatever you provided is wrong.";
       }
     }
+
     CustomizedMessageResolver customizedMessageResolver = new CustomizedMessageResolver();
     Validator customizedValidator =
         Validator.builder().withMessageResolver(customizedMessageResolver).build();

--- a/validation/src/test/scala/com/twitter/finatra/validation/tests/ValidatorTest.scala
+++ b/validation/src/test/scala/com/twitter/finatra/validation/tests/ValidatorTest.scala
@@ -16,6 +16,7 @@ import com.twitter.finatra.validation.{
 }
 import com.twitter.inject.Test
 import java.lang.annotation.Annotation
+import scala.collection.Seq
 
 class ValidatorTest extends Test {
 
@@ -26,10 +27,6 @@ class ValidatorTest extends Test {
    */
   test(
     "withMessageResolver should return a new Validator with all validators built with the given resolver") {
-    class CustomizedMessageResolver extends MessageResolver {
-      override def resolve(clazz: Class[_ <: Annotation], values: Any*): String =
-        "Whatever you provided is wrong."
-    }
     val customizedMessageResolver = new CustomizedMessageResolver()
 
     val validator = Validator.builder
@@ -194,4 +191,9 @@ class ValidatorTest extends Test {
     val AnnotatedClass(_, fields, _) = validator.getAnnotatedClass(clazz)
     fields.get(name).map(_.fieldValidators.map(_.annotation)).getOrElse(Array.empty[Annotation])
   }
+}
+
+class CustomizedMessageResolver extends MessageResolver {
+  override def resolve(clazz: Class[_ <: Annotation], values: Any*): String =
+    "Whatever you provided is wrong."
 }


### PR DESCRIPTION
Depends on #534 - last commit only.

Problem

utils is not cross-built for Scala 2.13.

Solution

Update utils module to cross-build for Scala 2.13 using new SBT
settings.

Result

utils is cross-built for Scala 2.13.