### PR TITLE
finatra-jackson: Fix unknown properties handling.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,6 +78,11 @@ Changed
 Fixed
 ~~~~~
 
+* finatra-jackson: (BREAKING API CHANGE) Fix "fail on unknown properties" during JSON deserialization.
+  Previously, the `CaseClassDeserializer` was only catching unknown fields when there were more fields
+  in the incomming JSON than in the case class. This fix may break some integrations where a client
+  sends a JSON including unknown fields. In such situation a `JsonMappingException` will be thrown.
+
 * inject-app: Having two sets of flag converters for primitive types (both Java and Scala) confuses
   the DI runtime, preventing the injection. We now have only a single set of converters, based off
   Scala primitive types.  ``PHAB_ID=D509192``

--- a/jackson/src/test/scala/com/twitter/finatra/jackson/tests/ScalaObjectMapperTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/jackson/tests/ScalaObjectMapperTest.scala
@@ -99,7 +99,7 @@ class ScalaObjectMapperTest extends AbstractScalaObjectMapperTest {
     result.fooClass should equal(FooClass("12345"))
   }
 
-  test("regular mapper handles unknown properties") {
+  test("regular mapper handles unknown properties while json provide MORE fields that case class") {
     // regular mapper -- doesn't fail
     mapper.parse[CaseClass](
       """
@@ -118,6 +118,30 @@ class ScalaObjectMapperTest extends AbstractScalaObjectMapperTest {
           |{
           |  "id": 12345,
           |  "name": "gadget",
+          |  "extra": "fail"
+          |}
+          |""".stripMargin
+      )
+    }
+  }
+
+  test("regular mapper handles unknown properties while json provide LESS fields that case class") {
+    // regular mapper -- doesn't fail
+    mapper.parse[CaseClassWithOption](
+      """
+        |{
+        |  "value": 12345,
+        |  "extra": "fail"
+        |}
+        |""".stripMargin
+    )
+
+    // mapper = loose, case class = annotated strict --> Fail
+    intercept[JsonMappingException] {
+      mapper.parse[StrictCaseClassWithOption](
+        """
+          |{
+          |  "value": 12345,
           |  "extra": "fail"
           |}
           |""".stripMargin

--- a/jackson/src/test/scala/com/twitter/finatra/jackson/tests/caseclasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/jackson/tests/caseclasses.scala
@@ -238,6 +238,9 @@ case class CaseClassWithOverloadedField(id: Long) {
   def id(prefix: String): String = prefix + id
 }
 
+@JsonIgnoreProperties(ignoreUnknown = false)
+case class StrictCaseClassWithOption(value: Option[String] = None)
+
 case class CaseClassWithOption(value: Option[String] = None)
 
 case class CaseClassWithJsonNode(value: JsonNode)


### PR DESCRIPTION
Problem

'FAIL_ON_UNKNOWN_PROPERTIES' Deserialisation Feature doesn't work as
 expected when the JSON contains less fields than the CaseClass.

In CaseClassDeserialiazer, the sequence of unknown fields is taken into
 account only when the number of fields provided in the Json is greater
 than the number of fields declared in the CaseClass.
For instance, when the case class contain some optional fields, the JSON
 can contain less fields then the case class and one of them can be
 unknown.

Solution

The solution is to always take into account unknown properties whatever
maybe the number of fields.

Result

When the JSON contains less fields overall than the CaseClass,
When the JSON provide one extra unknown field,
When the FAIL_ON_UNKNOWN_PROPERTIES is on,
Then an exception is thrown.