### PR TITLE
finatra-kafka:  Expose delivery timeout duration in KafkaProducerConfig

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Unreleased
 Added
 ~~~~~
 
+* finatra-kafka:  Expose delivery timeout duration in KafkaProducerConfig
+
 * inject-app: Add more Java-friendly constructors for the TestInjector. ``PHAB_ID=D520900``
 
 Changed

--- a/kafka/src/main/scala/com/twitter/finatra/kafka/producers/KafkaProducerConfig.scala
+++ b/kafka/src/main/scala/com/twitter/finatra/kafka/producers/KafkaProducerConfig.scala
@@ -141,6 +141,9 @@ trait KafkaProducerConfigMethods[Self] extends KafkaConfigMethods[Self] with Log
   def requestTimeout(duration: Duration): This =
     withConfig(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, duration)
 
+  def deliveryTimeout(duration: Duration): This =
+    withConfig(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, duration)
+
   def retries(retries: Int): This =
     withConfig(ProducerConfig.RETRIES_CONFIG, retries.toString)
 

--- a/kafka/src/main/scala/com/twitter/finatra/kafka/producers/KafkaProducerConfig.scala
+++ b/kafka/src/main/scala/com/twitter/finatra/kafka/producers/KafkaProducerConfig.scala
@@ -80,6 +80,9 @@ trait KafkaProducerConfigMethods[Self] extends KafkaConfigMethods[Self] with Log
 
   def connectionsMaxIdle(duration: Duration): This =
     withConfig(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, duration)
+  
+  def deliveryTimeout(duration: Duration): This =
+    withConfig(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, duration)
 
   def enableIdempotence(boolean: Boolean): This =
     withConfig(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, boolean.toString)
@@ -140,9 +143,6 @@ trait KafkaProducerConfigMethods[Self] extends KafkaConfigMethods[Self] with Log
 
   def requestTimeout(duration: Duration): This =
     withConfig(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, duration)
-
-  def deliveryTimeout(duration: Duration): This =
-    withConfig(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, duration)
 
   def retries(retries: Int): This =
     withConfig(ProducerConfig.RETRIES_CONFIG, retries.toString)


### PR DESCRIPTION
Problem

Kafka producer configuration `delivery.timeout.ms` is not exposed in `KafkaProducerConfig`. 
It's a useful config to set an upper bound on the time to report success or failure after a call to `producer.send()` returns (kafka default : MAX_INT)

Solution

Expose delivery timeout duration in KafkaProducerConfig object. No associated flag in kafka-stream module as it doesn't really make sense to change it default value for a stream application 

Describe the modifications you've done.

Addd of `deliveryTimeout(duration: Duration)` in `ProducerConfig` object.
