### PR TITLE
inject-thrift: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -645,7 +645,7 @@ lazy val injectRequestScope = (project in file("inject/inject-request-scope"))
   )
 
 lazy val injectThrift = (project in file("inject/inject-thrift"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-thrift",
     moduleName := "inject-thrift",


### PR DESCRIPTION
Problem

inject-thrift is not cross-built for Scala 2.13.

Solution

Update inject-thrift module to cross-build for Scala 2.13 using new SBT
settings.

Result

inject-thrift is cross-built for Scala 2.13.
