### PR TITLE
inject-mdc/thrift: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -601,7 +601,7 @@ lazy val injectServer = (project in file("inject/inject-server"))
   )
 
 lazy val injectMdc = (project in file("inject/inject-mdc"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-mdc",
     moduleName := "inject-mdc",

--- a/build.sbt
+++ b/build.sbt
@@ -1025,7 +1025,7 @@ lazy val thriftTestJarSources =
     "com/twitter/finatra/thrift/ThriftClient",
     "com/twitter/finatra/thrift/ThriftTest")
 lazy val thrift = project
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "finatra-thrift",
     moduleName := "finatra-thrift",

--- a/thrift/src/main/scala/com/twitter/finatra/thrift/routing/ThriftWarmup.scala
+++ b/thrift/src/main/scala/com/twitter/finatra/thrift/routing/ThriftWarmup.scala
@@ -9,7 +9,7 @@ import javax.inject.Inject
 private object ThriftWarmup {
 
   /**  Function curried as the default arg for the responseCallback: M#SuccessType => Unit parameter. */
-  val unitFunction: AnyRef => Unit = _ => Unit
+  val unitFunction: AnyRef => Unit = _ => ()
 }
 
 /**

--- a/thrift/src/test/scala/com/twitter/finatra/thrift/tests/ReqRepServicePerEndpointTest.scala
+++ b/thrift/src/test/scala/com/twitter/finatra/thrift/tests/ReqRepServicePerEndpointTest.scala
@@ -12,7 +12,9 @@ import java.nio.charset.{StandardCharsets => JChar}
 object ReqRepServicePerEndpointTest {
   /* filter out com.twitter.finagle header keys */
   def filteredHeaders(headers: HeaderMap): Map[String, Seq[Buf]] = {
-    headers.toMap.filterKeys(key => !key.startsWith("com.twitter.finagle"))
+    headers.toMap.filter {
+      case (key, _) => !key.startsWith("com.twitter.finagle")
+    }
   }
 
   def printHeaders(headers: Map[String, Seq[Buf]]): String = {


### PR DESCRIPTION
Problem

inject-mdc and thrift modules are not cross-built for Scala 2.13.

Solution

Update modules to cross-build for Scala 2.13 using new SBT
settings.

Result

inject-mdc/thrift modules are cross-built for Scala 2.13.