### PR TITLE
inject-request-scope: Cross-build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -631,7 +631,7 @@ lazy val injectSlf4j = (project in file("inject/inject-slf4j"))
   )
 
 lazy val injectRequestScope = (project in file("inject/inject-request-scope"))
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "inject-request-scope",
     moduleName := "inject-request-scope",


### PR DESCRIPTION
Problem

inject-request-scope is not cross-built for Scala 2.13.

Solution

Update inject-request-scope module to cross-build for Scala 2.13 using new SBT
settings.

Result

inject-request-scope is cross-built for Scala 2.13.