### PR TITLE
httpclient/jackson/http - Cross build for Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val versions = new {
 lazy val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
 
 lazy val withTwoThirteen = Seq(
+  scalaVersion := "2.13.1",
   crossScalaVersions += "2.13.1",
   libraryDependencies += scalaCollectionCompat,
   scalacOptions := {
@@ -910,7 +911,7 @@ lazy val httpTestJarSources =
     "com/twitter/finatra/http/response/DefaultResponseBuilder"
   )
 lazy val http = project
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "finatra-http",
     moduleName := "finatra-http",
@@ -919,6 +920,7 @@ lazy val http = project
       "com.twitter" %% "finagle-exp" % versions.twLibVersion,
       "com.twitter" %% "finagle-http" % versions.twLibVersion,
       "commons-fileupload" % "commons-fileupload" % versions.commonsFileupload,
+      "javax.servlet" % "servlet-api" % "2.4" % Provided,
       "com.novocode" % "junit-interface" % "0.11" % Test,
       "org.slf4j" % "slf4j-simple" % versions.slf4j % "test-internal",
       "com.twitter" %% "util-security-test-certs" % versions.twLibVersion % Test

--- a/build.sbt
+++ b/build.sbt
@@ -825,7 +825,7 @@ lazy val jacksonTestJarSources =
     "com/twitter/finatra/json/JsonDiff"
   )
 lazy val jackson = project
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "finatra-jackson",
     moduleName := "finatra-jackson",

--- a/build.sbt
+++ b/build.sbt
@@ -987,7 +987,7 @@ lazy val httpMustache = (project in file("http-mustache"))
 lazy val httpclientTestJarSources =
   Seq("com/twitter/finatra/httpclient/test/")
 lazy val httpclient = project
-  .settings(projectSettings)
+  .settings(projectSettings, withTwoThirteen)
   .settings(
     name := "finatra-httpclient",
     moduleName := "finatra-httpclient",

--- a/http/src/main/scala/com/twitter/finatra/http/exceptions/ExceptionMapperCollection.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/exceptions/ExceptionMapperCollection.scala
@@ -4,9 +4,9 @@ import scala.collection.mutable.ArrayBuffer
 
 /**
  * Represents a collection of [[com.twitter.finatra.http.exceptions.ExceptionMapper]]s
- * which is a {{{Traversable[Manifest[ExceptionMapper[_]]]}}}.
+ * which is an {{{Iterable[Manifest[ExceptionMapper[_]]]}}}.
  */
-class ExceptionMapperCollection extends Traversable[Manifest[ExceptionMapper[_]]] {
+class ExceptionMapperCollection extends Iterable[Manifest[ExceptionMapper[_]]] {
 
   private[this] val manifests = ArrayBuffer[Manifest[ExceptionMapper[_]]]()
 
@@ -21,5 +21,5 @@ class ExceptionMapperCollection extends Traversable[Manifest[ExceptionMapper[_]]
 
   override def foreach[U](f: (Manifest[ExceptionMapper[_]]) => U): Unit = manifests.foreach(f)
 
-  override def seq: Traversable[Manifest[ExceptionMapper[_]]] = manifests.seq
+  override def iterator: Iterator[Manifest[ExceptionMapper[_]]] = manifests.iterator
 }

--- a/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/DefaultMessageBodyWriterImpl.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/DefaultMessageBodyWriterImpl.scala
@@ -43,7 +43,7 @@ private[finatra] class DefaultMessageBodyWriterImpl @Inject() (
         WriterResponse(octetStream, bytes)
       case "" =>
         WriterResponse.EmptyResponse
-      case Unit =>
+      case () =>
         WriterResponse.EmptyResponse
       case _: BoxedUnit =>
         WriterResponse.EmptyResponse

--- a/http/src/main/scala/com/twitter/finatra/http/routing/HttpRouter.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/routing/HttpRouter.scala
@@ -399,14 +399,14 @@ class HttpRouter @Inject() (
     controller: Controller,
     filter: Option[HttpFilter] = None
   ): Seq[Route] = {
-    val routes = filter match {
+    val routes = (filter match {
       case Some(controllerFilter) =>
         controller.routeBuilders.map(
           _.build(callbackConverter, injector).withFilter(controllerFilter)
         )
       case _ =>
         controller.routeBuilders.map(_.build(callbackConverter, injector))
-    }
+    }).toSeq
 
     registerRoutes(routes)
     registerGlobalFilter(globalFilter)
@@ -436,7 +436,7 @@ class HttpRouter @Inject() (
       route.path.startsWith(FinatraAdminPrefix) || route.admin
     }
     assertAdminRoutes(adminRoutes)
-    RoutesByType(external = externalRoutes, admin = adminRoutes)
+    RoutesByType(external = externalRoutes.toSeq, admin = adminRoutes.toSeq)
   }
 
   // non-constant routes MUST start with /admin/finatra

--- a/http/src/main/scala/com/twitter/finatra/http/routing/HttpWarmup.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/routing/HttpWarmup.scala
@@ -11,7 +11,7 @@ private object HttpWarmup {
   val userAgent = "http-warmup-client"
 
   /**  Function curried as the default arg for the responseCallback: Response => Unit parameter. */
-  val unitFunction: Response => Unit = _ => Unit
+  val unitFunction: Response => Unit = _ => ()
 }
 
 /**

--- a/http/src/test/java/com/twitter/finatra/http/tests/integration/doeverything/main/TestModuleB.java
+++ b/http/src/test/java/com/twitter/finatra/http/tests/integration/doeverything/main/TestModuleB.java
@@ -1,16 +1,12 @@
 package com.twitter.finatra.http.tests.integration.doeverything.main;
 
-import java.util.Collection;
-import java.util.Collections;
-
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
-
 import com.google.inject.Module;
-
 import com.twitter.app.Flag;
 import com.twitter.app.Flaggable;
 import com.twitter.inject.TwitterModule;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public final class TestModuleB extends TwitterModule {
   // FOR TESTING ONLY
@@ -27,16 +23,11 @@ public final class TestModuleB extends TwitterModule {
   }
 
   @Override
-  public Seq<Module> modules() {
-    return JavaConverters.asScalaIteratorConverter(
-        Collections.<Module>singletonList(
-            new TestModuleA()).iterator()).asScala().toSeq();
-  }
-
-  @Override
   public Collection<Module> javaModules() {
-    return Collections.singletonList(
-        new TestModuleC());
+    ArrayList<Module> modules = new ArrayList<>();
+    modules.add(new TestModuleA());
+    modules.add(new TestModuleC());
+    return modules;
   }
 
   @Override

--- a/http/src/test/scala/com/twitter/finatra/http/tests/request/RequestUtilsTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/request/RequestUtilsTest.scala
@@ -22,9 +22,7 @@ class RequestUtilsTest extends Test with Mockito {
   }
 
   test("throw BadRequestException when missing host header for pathUrl") {
-    val request = mock[Request]
-    request.headerMap returns HeaderMap()
-    request.host returns None
+    val request = Request()
 
     intercept[BadRequestException] {
       RequestUtils.pathUrl(request)
@@ -32,18 +30,15 @@ class RequestUtilsTest extends Test with Mockito {
   }
 
   test("pathUrl with slash") {
-    val request = mock[Request]
-    request.headerMap returns HeaderMap()
-    request.host returns Some("www.foo.com")
-    request.path returns "/part/next/end/"
+    val request = Request("/part/next/end/")
+    request.host = "www.foo.com"
 
     val result = RequestUtils.pathUrl(request)
     result should equal("http://www.foo.com/part/next/end/")
   }
 
   test("respondTo */* content type in request when no accept header is sent") {
-    val request = mock[Request]
-    request.headerMap returns HeaderMap()
+    val request = Request()
 
     val response = RequestUtils.respondTo(request) {
       case _ => true
@@ -53,8 +48,8 @@ class RequestUtilsTest extends Test with Mockito {
   }
 
   test("respondTo text/html content-type in request") {
-    val request = mock[Request]
-    request.headerMap returns HeaderMap(Fields.Accept -> ContentType.HTML.toString)
+    val request = Request()
+    request.headerMap.add(Fields.Accept, ContentType.HTML.toString)
 
     val response = RequestUtils.respondTo(request) {
       case ContentType.HTML => true
@@ -65,8 +60,8 @@ class RequestUtilsTest extends Test with Mockito {
   }
 
   test("respondTo application/json content-type in request") {
-    val request = mock[Request]
-    request.headerMap returns HeaderMap(Fields.Accept -> ContentType.JSON.toString)
+    val request = Request()
+    request.headerMap.add(Fields.Accept, ContentType.JSON.toString)
 
     val response = RequestUtils.respondTo(request) {
       case ContentType.JSON => true
@@ -77,9 +72,9 @@ class RequestUtilsTest extends Test with Mockito {
   }
 
   test("return NotAcceptableException for request") {
-    val request = mock[Request]
+    val request = Request()
     // accept application/json
-    request.headerMap returns HeaderMap(Fields.Accept -> ContentType.JSON.toString)
+    request.headerMap.add(Fields.Accept, ContentType.JSON.toString)
 
     intercept[NotAcceptableException] {
       // only handle text/html

--- a/jackson/src/main/scala/com/twitter/finatra/jackson/ScalaObjectMapper.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/jackson/ScalaObjectMapper.scala
@@ -68,7 +68,7 @@ object ScalaObjectMapper {
 
   /** The default for mutating the underlying [[JacksonScalaObjectMapperType]] with additional configuration */
   private[jackson] val DefaultAdditionalMapperConfigurationFn: JacksonObjectMapper => Unit =
-    _ => Unit
+    _ => ()
 
   /** The default setting to enable case class validation during case class deserialization */
   private[jackson] val DefaultValidation: Boolean = true

--- a/jackson/src/main/scala/com/twitter/finatra/jackson/caseclass/CaseClassDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/jackson/caseclass/CaseClassDeserializer.scala
@@ -424,7 +424,7 @@ private[jackson] class CaseClassDeserializer(
     jsonParser: JsonParser,
     context: DeserializationContext,
     jsonNode: JsonNode
-  ): (Array[Object], mutable.ArrayBuffer[CaseClassFieldMappingException]) = {
+  ): (Array[Object], Seq[CaseClassFieldMappingException]) = {
     /* Mutable Fields */
     var constructorValuesIdx = 0
     val constructorValues = new Array[Object](numConstructorArgs)
@@ -547,7 +547,7 @@ private[jackson] class CaseClassDeserializer(
       constructorValuesIdx += 1
     }
 
-    (constructorValues, errors)
+    (constructorValues, errors.toSeq)
   }
 
   private[this] def isScalaEnumerationType(clazz: Class[_]): Boolean =
@@ -625,7 +625,7 @@ private[jackson] class CaseClassDeserializer(
               case Some(annotatedField) => annotatedField.fieldValidators
               case _ => Array.empty[FieldValidator]
             }
-          )
+          ).toSeq
         } yield {
           CaseClassFieldMappingException(
             CaseClassFieldMappingException.PropertyPath.leaf(field.name),
@@ -659,7 +659,7 @@ private[jackson] class CaseClassDeserializer(
           }
         }
 
-        val results = v.validateMethods(obj, methods)
+        val results = v.validateMethods(obj, methods).toSeq
         if (results.nonEmpty) {
           val methodValidationErrors: Seq[Iterable[CaseClassFieldMappingException]] = for {
             result <- results if !result.isValid

--- a/jackson/src/main/scala/com/twitter/finatra/jackson/streaming/AsyncJsonParser.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/jackson/streaming/AsyncJsonParser.scala
@@ -71,7 +71,7 @@ private[finatra] class AsyncJsonParser {
       }
     }
 
-    result
+    result.toSeq
   }
 
   private def getSlicedBuf: Buf = {


### PR DESCRIPTION
Problem

httpclient, jackson, and http modules don't build for 2.13

Solution

Cross build these modules.

#### Notes on changes

The commit for the jackson module brings along some changes necessary for convert Scala 2.12 usages of Seq to Scala 2.13 compliant usages, as detailed [here](https://docs.scala-lang.org/overviews/core/collections-migration-213.html#scalaseq-varargs-and-scalaindexedseq-migration). There are performance considerations for these changes, as detailed in https://github.com/twitter/finagle/issues/818. 

For now, the most important aspect here is ensuring that these changes don't regress 2.12 performance. For jackson, I've run the JsonBenchmark against 2.12.11 with and without the changes I've made here. There doesn't seem to be an impact in performance with the changes. The results are here: https://gist.github.com/chrisbenincasa/ff654689fb79ca6443e3b99900a3a824

--- 

The commit for `http` contains some of the Seq changes, but not on high volume code paths, from what I can tell.

I had to remove the mocking from RequestUtilsTest.scala, because Mockito was throwing errors when mocking HeaderMap due to some Map methods being made `final` in 2.13.

I also introduced 2.13+ and 2.13- directory support for the build in this commit. 

Result

httpclient, jackson, and http modules are built for 2.13.
