### PR TITLE
finatra-jackson: add @NullValueAllowed annotation and functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Note that ``RB_ID=#`` and ``PHAB_ID=#`` correspond to associated message in comm
 Unreleased
 ----------
 
+Added
+~~~~~
+
+* finatra-jackson: Add `@NullValueAllowed` field annotations, allowing to accept json null values.
+
 Fixed
 ~~~~~
 

--- a/jackson/src/main/scala/com/twitter/finatra/jackson/caseclass/CaseClassField.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/jackson/caseclass/CaseClassField.scala
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.node.TreeTraversingParser
 import com.fasterxml.jackson.databind.util.ClassUtil
 import com.twitter.conversions.StringOps._
 import com.twitter.finatra.jackson.caseclass.exceptions.CaseClassFieldMappingException
-import com.twitter.finatra.json.annotations.InjectableValue
+import com.twitter.finatra.json.annotations.{InjectableValue, NullValueAllowed}
 import com.twitter.inject.Logging
 import com.twitter.util.reflect.Annotations
 import java.lang.annotation.Annotation
@@ -234,6 +234,8 @@ private[jackson] case class CaseClassField private (
           fieldJsonNode,
           parseFieldValue(context, codec, fieldJsonNode, forProperty))
       }
+    } else if (fieldJsonNode != null && fieldJsonNode.isNull && annotations.exists(_.isInstanceOf[NullValueAllowed])) {
+      null
     } else defaultValueOrException(isIgnored)
   }
 

--- a/jackson/src/test/scala/com/twitter/finatra/jackson/caseclasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/jackson/caseclasses.scala
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.node.ValueNode
 import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
 import com.twitter.finatra.jackson.caseclass.SerdeLogging
+import com.twitter.finatra.json.annotations.NullValueAllowed
 import com.twitter.finatra.validation.constraints._
 import com.twitter.finatra.validation.{CommonMethodValidations, ErrorCode}
 import com.twitter.inject.domain.WrappedValue
@@ -774,3 +775,7 @@ case class CaseClassShouldUseKebabCaseFromMixin(willThisGetTheRightCasing: Boole
 
 @JsonNaming
 case class UseDefaultNamingStrategy(thisFieldShouldUseDefaultPropertyNamingStrategy: Boolean)
+
+case class NullableField(@NullValueAllowed() value: String)
+
+case class NullableFieldDefault(@NullValueAllowed() value: String = "foo")

--- a/jackson/src/test/scala/com/twitter/finatra/jackson/caseclasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/jackson/caseclasses.scala
@@ -776,6 +776,6 @@ case class CaseClassShouldUseKebabCaseFromMixin(willThisGetTheRightCasing: Boole
 @JsonNaming
 case class UseDefaultNamingStrategy(thisFieldShouldUseDefaultPropertyNamingStrategy: Boolean)
 
-case class NullableField(@NullValueAllowed() value: String)
+case class NullableField(@NullValueAllowed value: String)
 
-case class NullableFieldDefault(@NullValueAllowed() value: String = "foo")
+case class NullableFieldDefault(@NullValueAllowed value: String = "foo")

--- a/jackson/src/test/scala/com/twitter/finatra/jackson/serde/NullableFieldTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/jackson/serde/NullableFieldTest.scala
@@ -1,0 +1,32 @@
+package com.twitter.finatra.jackson.serde
+
+import com.twitter.finatra.jackson.caseclass.exceptions.CaseClassMappingException
+import com.twitter.finatra.jackson.{CaseClassWithEnum, NullableField, NullableFieldDefault, ScalaObjectMapper}
+import com.twitter.inject.Test
+
+class NullableFieldTest extends Test {
+  private val mapper: ScalaObjectMapper = ScalaObjectMapper()
+
+  def parse[T: Manifest](string: String): T = {
+    mapper.parse[T](string)
+  }
+
+  test("Allow null values") {
+    parse[NullableField]("""{"value":null}""") should be(NullableField(null))
+  }
+
+  test("Fail on missing value even when null allowed") {
+    val e = intercept[CaseClassMappingException] {
+      parse[NullableField]("""{}""")
+    }
+    e.errors.map { _.getMessage } should equal(Seq("value: field is required"))
+  }
+
+  test("Allow null values when default is provided") {
+    parse[NullableFieldDefault]("""{"value":null}""") should be(NullableFieldDefault(null))
+  }
+
+  test("Use default when null is allowed, but not provided") {
+    parse[NullableFieldDefault]("""{}""") should be(NullableFieldDefault("foo"))
+  }
+}

--- a/json-annotations/src/main/java/com/twitter/finatra/json/annotations/NullValueAllowed.java
+++ b/json-annotations/src/main/java/com/twitter/finatra/json/annotations/NullValueAllowed.java
@@ -1,0 +1,17 @@
+package com.twitter.finatra.json.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation that defines a field for which a null is a valid value.
+ *
+ * This does not change the optionality of the field.
+ * Mandatory fields still must have a value, but the value can be a null.
+ *
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullValueAllowed {}


### PR DESCRIPTION
Problem

In some cases null is a valida value for a field. Currently there is no way
how to allow nulls just for some specific field.

Solution

Add field annotation and accept json null for all annotated fields.
