### PR TITLE
Update sbt to 1.6.1, which upgrades the log4j dependency to 2.17.1

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.8


### PR DESCRIPTION
# Problem

sbt has a dependency on log4j2, which was shown recently to have serious security vulnerabilities. The version of sbt currently used by finatra, 1.5.5, is vulnerable.

# Solution

Update to use sbt 1.6.1, which upgrades the log4j dependency to log4j 2.17.1, which resolves these security vulnerabilities.

From https://eed3si9n.com/sbt-1.6.1:
>sbt 1.6.1 updates log4j 2 to 2.17.1, which fixes a remote code execution vulnerability when attacker controls configuration (CVE-2021-44832) #6765 by @eed3si9n

For details, see [The state of the log4j CVE in the Scala ecosystem](https://www.scala-lang.org/blog-detail/2021/12/16/state-of-log4j-in-scala-ecosystem.html)
