### PR TITLE
Portable shebang

### DIFF
--- a/examples/benchmark/local_benchmark.sh
+++ b/examples/benchmark/local_benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##
 # Run from the top-level finatra project directory:

--- a/pushsite.bash
+++ b/pushsite.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 savedir=$(pwd)

--- a/sbt
+++ b/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
Problem

- /bin/bash is not available on non-FHS distros, such as NixOS

Solution

- replace `/bin/bash` with `/usr/bin/env bash` 	

Result


See also

https://github.com/twitter/dodo/pull/15
https://github.com/twitter/finagle/pull/959
https://github.com/twitter/scrooge/pull/366
https://github.com/twitter/util/pull/314
https://github.com/twitter/twitter-server/pull/77