### PR TITLE
fix commons-fileupload dependency for high CVEs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
       - name: echo javac version
         run: javac -J-Xmx32m -version
       - name: cache build dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-build-deps
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val versions = new {
 
   // All Twitter library releases are date versioned as YY.MM.patch
   val twLibVersion = releaseVersion
-  val commonsFileupload = "1.4"
+  val commonsFileupload = "1.5"
   val guice = "5.1.0"
   val jackson = "2.14.3"
   val jodaConvert = "2.2.3"


### PR DESCRIPTION
Update commons-fileupload to 1.5 to address CVE-2023-24998.

This PR upgrades commons-fileupload from version 1.4 to 1.5.

reference: https://nvd.nist.gov/vuln/detail/cve-2023-24998